### PR TITLE
Breaking change: VM Generation and VHD/VHDX files. Fixes #4

### DIFF
--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -77,8 +77,8 @@ function Set-TargetResource
         [String]$Path,
 
         # Virtual machine generation
-		[ValidateRange(1,2)]
-		[UInt32]$Generation = 1,
+        [ValidateRange(1,2)]
+        [UInt32]$Generation = 1,
 
         # Startup RAM for the VM
         [ValidateRange(32MB,17342MB)]

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -34,7 +34,7 @@ function Get-TargetResource
         SwitchName       = $vmObj.NetworkAdapters[0].SwitchName
         State            = $vmobj.State
         Path             = $vmobj.Path
-        Generation       = if($vmobj.Generation -eq 1){"Vhd"}else{"Vhdx"}
+        Generation       = $vmobj.Generation
         StartupMemory    = $vmobj.MemoryStartup
         MinimumMemory    = $vmobj.MemoryMinimum
         MaximumMemory    = $vmobj.MemoryMaximum
@@ -76,9 +76,9 @@ function Set-TargetResource
         # Folder where the VM data will be stored
         [String]$Path,
 
-        # Associated Virtual disk format - Vhd or Vhdx
-        [ValidateSet("Vhd","Vhdx")]
-        [String]$Generation = "Vhd",
+        # Virtual machine generation
+		[ValidateRange(1,2)]
+		[UInt32]$Generation = 1,
 
         # Startup RAM for the VM
         [ValidateRange(32MB,17342MB)]
@@ -222,11 +222,11 @@ function Set-TargetResource
             $parameters = @{}
             $parameters["Name"] = $Name
             $parameters["VHDPath"] = $VhdPath
+            $parameters["Generation"] = $Generation
 
             # Optional parameters
             if($SwitchName){$parameters["SwitchName"]=$SwitchName}
             if($Path){$parameters["Path"]=$Path}
-            if($Generation){$parameters["Generation"]=if($Generation -eq "Vhd"){1}else{2}}
             $defaultStartupMemory = 512MB
             if($StartupMemory){$parameters["MemoryStartupBytes"]=$StartupMemory}
             elseif($MinimumMemory -and $defaultStartupMemory -lt $MinimumMemory){$parameters["MemoryStartupBytes"]=$MinimumMemory}
@@ -296,9 +296,9 @@ function Test-TargetResource
         # Folder where the VM data will be stored
         [String]$Path,
 
-        # Associated Virtual disk format - Vhd or Vhdx
-        [ValidateSet("Vhd","Vhdx")]
-        [String]$Generation = "Vhd",
+        # Virtual machine generation
+        [ValidateRange(1,2)]
+        [UInt32]$Generation = 1,
 
         # Startup RAM for the VM
         [ValidateRange(32MB,17342MB)]
@@ -369,11 +369,13 @@ function Test-TargetResource
         Throw "StartupMemory($StartupMemory) should not be greater than MaximumMemory($MaximumMemory)"
     }        
 
-    # Check if the generation matches the VhdPath extenstion
-    if($Generation -and ($VhdPath.Split('.')[-1] -ne $Generation))
+    <#  VM Generation has no direct relation to the virtual hard disk format and cannot be changed
+        after the virtual machine has been created. Generation 2 VMs do not support .VHD files.  #>
+    if(($Generation -eq 2) -and ($VhdPath.Split('.')[-1] -eq 'vhd'))
     {
-        Throw "Generation $geneartion should match virtual disk extension $($VhdPath.Split('.')[-1])"
+        Throw "Generation 2 virtual machines do not support the .VHD virtual disk extension."
     }
+
 
     # Check if $Path exist
     if($Path -and !(Test-Path -Path $Path))
@@ -396,6 +398,7 @@ function Test-TargetResource
             if($state -and ($vmObj.State -ne $State)){return $false}
             if($StartupMemory -and ($vmObj.MemoryStartup -ne $StartupMemory)){return $false}
             if($MACAddress -and ($vmObj.NetWorkAdapters.MacAddress -notcontains $MACAddress)){return $false}
+            if($Generation -ne $vmObj.Generation){return $false}
             if($ProcessorCount -and ($vmObj.ProcessorCount -ne $ProcessorCount)){return $false}
             if($MaximumMemory -and ($vmObj.MemoryMaximum -ne $MaximumMemory)){return $false}
             if($MinimumMemory -and ($vmObj.MemoryMinimum -ne $MinimumMemory)){return $false}
@@ -510,4 +513,3 @@ function Get-VMIPAddress
 #endregion
 
 Export-ModuleMember -Function *-TargetResource
-

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.schema.mof
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0"), FriendlyName("xVMHyperV")]
+﻿[ClassVersion("1.0.0"), FriendlyName("xVMHyperV")]
 class MSFT_xVMHyperV : OMI_BaseResource
 {
     [Key, Description("Name of the VM")] String Name;
@@ -6,7 +6,7 @@ class MSFT_xVMHyperV : OMI_BaseResource
     [Write, Description("Virtual switch associated with the VM")] String SwitchName;
     [Write, Description("State of the VM."), ValueMap{"Running","Paused","Off"}, Values{"Running","Paused","Off"}] String State;
     [Write, Description("Folder where the VM data will be stored")] String Path;
-    [Write, Description("Associated Virtual disk format - Vhd or Vhdx"), ValueMap{"Vhd","Vhdx"}, Values{"Vhd","Vhdx"}] String Generation;
+    [Write, Description("Virtual machine generation")] Uint32 String Generation;
     [Write, Description("Startup RAM for the VM.")] Uint64 StartupMemory;
     [Write, Description("Minimum RAM for the VM. This enables dynamic memory.")] Uint64 MinimumMemory;
     [Write, Description("Maximum RAM for the VM. This enable dynamic memory.")] Uint64 MaximumMemory;

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This resource is particularly useful when bootstrapping DSC Configurations into 
 * **SwitchName**: Virtual switch associated with the VM 
 * **State**: State of the VM: { Running | Paused | Off }
 * **Path**: Folder where the VM data will be stored
-* **Generation**: Virtual machine generaion { 1 | 2 }.
+* **Generation**: Virtual machine generation { 1 | 2 }.
 Generation 2 virtual machines __only__ support VHDX files.
 * **StartupMemory**: Startup RAM for the VM 
 * **MinimumMemory**: Minimum RAM for the VM. 
@@ -69,7 +69,10 @@ Please see the Examples section for more details.
 ## Versions
 
 ### Unreleased
-* Decoupled VM generation from underlying VHD formar in xVMHyperV resourse.
+* Decoupled VM generation from underlying VHD format in xVMHyperV resource.
+ * The initial generation property was tied to the virtual disk format which was incorrect and has been rectified.
+ * __This is a breaking change__ due to the xVMHyperV.Generation property has changing from a String to an Integer.
+ * However, this change will only impact configurations that have previously explicitly specified the VM generation is either "vhd" or "vhdx".
 
 ### 2.4.0.0
 * Fixed VM power state issue in xVMHyperV resource
@@ -289,7 +292,7 @@ Configuration Sample_xVMHyperV_Simple
         {
             Ensure     = 'Present'
             Name       = $VMName
-            VhdPath    = $VhdPathx
+            VhdPath    = $VhdxPath
             Generation = 2
             DependsOn  = '[WindowsFeature]HyperV'
         }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This resource is particularly useful when bootstrapping DSC Configurations into 
 * **SwitchName**: Virtual switch associated with the VM 
 * **State**: State of the VM: { Running | Paused | Off }
 * **Path**: Folder where the VM data will be stored
-* **Generation**: Associated Virtual disk format { Vhd | Vhdx }
+* **Generation**: Virtual machine generaion { 1 | 2 }.
+Generation 2 virtual machines __only__ support VHDX files.
 * **StartupMemory**: Startup RAM for the VM 
 * **MinimumMemory**: Minimum RAM for the VM. 
 Setting this property enables dynamic memory.
@@ -44,6 +45,12 @@ Setting this property enables dynamic memory.
 * **WaitForIP**: If specified, waits for the VM to get valid IP address
 * **RestartIfNeeded**: If specified, will shutdown and restart the VM as needed for property changes
 * **Ensure**: Ensures that the VM is Present or Absent
+
+The following xVMHyper-V properties **cannot** be changed after VM creation:
+
+* VhdPath
+* Path
+* Generation
 
 ### xVMSwitch
 
@@ -61,6 +68,9 @@ Please see the Examples section for more details.
 
 ## Versions
 
+### Unreleased
+* Decoupled VM generation from underlying VHD formar in xVMHyperV resourse.
+
 ### 2.4.0.0
 * Fixed VM power state issue in xVMHyperV resource
 
@@ -69,7 +79,6 @@ Please see the Examples section for more details.
 * Fixed check for presence of param AllowManagementOS.
 
 ### 2.2.1
-
 
 ### 2.1
 
@@ -87,7 +96,6 @@ Please see the Examples section for more details.
     - xVhd 
     - xVMHyperV 
     - xVMSwitch  
-
 
 ## Examples
 
@@ -147,7 +155,7 @@ Configuration Sample_EndToEndXHyperV_RunningVM
 
     }
 
-    # create the testVM out of the vhd.
+    # create the generation 1 testVM out of the vhd.
     xVMHyperV testvm
     {
         Name = "$($name)_vm"
@@ -247,9 +255,9 @@ Configuration Sample_xVhd_DiffVHD
 }
 ```
 
-### Create a VM for a given VHD
+### Create a generation 2 VM for a given VHD
 
-This configuration will create a VM, given a VHD, on Hyper-V host.
+This configuration will create a VM, given a VHDX, on Hyper-V host.
 
 ```powershell
 Configuration Sample_xVMHyperV_Simple
@@ -262,7 +270,7 @@ Configuration Sample_xVMHyperV_Simple
         [string]$VMName,
 
         [Parameter(Mandatory)]
-        [string]$VhdPath        
+        [string]$VhdxPath        
     )
 
     Import-DscResource -module xHyper-V
@@ -281,8 +289,8 @@ Configuration Sample_xVMHyperV_Simple
         {
             Ensure     = 'Present'
             Name       = $VMName
-            VhdPath    = $VhdPath
-            Generation = $VhdPath.Split('.')[-1]
+            VhdPath    = $VhdPathx
+            Generation = 2
             DependsOn  = '[WindowsFeature]HyperV'
         }
     }
@@ -305,6 +313,10 @@ Configuration Sample_xVMHyperV_DynamicMemory
 
         [Parameter(Mandatory)]
         [string]$VhdPath,
+
+        [Parameter(Mandatory)]
+        [ValidateSet(1,2)]
+        [unit32]$Generation,
 
         [Parameter(Mandatory)]
         [Uint64]$StartupMemory,
@@ -333,7 +345,7 @@ Configuration Sample_xVMHyperV_DynamicMemory
             Ensure        = 'Present'
             Name          = $VMName
             VhdPath       = $VhdPath
-            Generation    = $VhdPath.Split('.')[-1]
+            Generation    = $Generation
             StartupMemory = $StartupMemory
             MinimumMemory = $MinimumMemory
             MaximumMemory = $MaximumMemory
@@ -359,6 +371,10 @@ Configuration Sample_xVMHyperV_Complete
 
         [Parameter(Mandatory)]
         [string]$VhdPath,
+
+        [Parameter(Mandatory)]
+        [ValidateSet(1,2)]
+        [unit32]$Generation,
 
         [Parameter(Mandatory)]
         [Uint64]$StartupMemory,
@@ -404,7 +420,7 @@ Configuration Sample_xVMHyperV_Complete
             SwitchName      = $SwitchName
             State           = $State
             Path            = $Path
-            Generation      = $VhdPath.Split('.')[-1]
+            Generation      = $Generation
             StartupMemory   = $StartupMemory
             MinimumMemory   = $MinimumMemory
             MaximumMemory   = $MaximumMemory


### PR DESCRIPTION
* Fixes VM generation implementation.
* Changed Generation property to Uint32 and updated .schema.mof accordingly.
* Throws during Test-TargetResource if Generation = 2 and VhdPath = *.vhd
* Updated README.md to reflect the property type change.
* Added test coverage