### PR TITLE
Update MSFT_xVhdFileDirectory.psm1

### DIFF
--- a/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.psm1
+++ b/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.psm1
@@ -38,7 +38,7 @@ function Get-TargetResource
     $itemsFound = foreach($Item in $FileDirectory)
     {
         $item = GetItemToCopy -item $item
-        $mountedDrive =  $mountVHD | Get-Disk | Get-Partition | Get-Volume
+        $mountedDrive =  $mountVHD | Get-Disk | Get-Partition | Get-Volume | Where{$_.DriveLetter}
         $letterDrive  = "$($mountedDrive.DriveLetter):\" 
        
         # show the drive letters.
@@ -98,7 +98,7 @@ function Set-TargetResource
             # show the drive letters.
             Get-PSDrive | Write-Verbose
 
-            $mountedDrive = $mountedVHD | Get-Disk | Get-Partition | Get-Volume
+            $mountedDrive = $mountedVHD | Get-Disk | Get-Partition | Get-Volume | Where{$_.DriveLetter}
             
             foreach ($item in $FileDirectory)
             {
@@ -185,7 +185,7 @@ function Test-TargetResource
         # Show the drive letters after mount 
         Get-PSDrive | Write-Verbose
 
-        $mountedDrive = $mountedVHD | Get-Disk | Get-Partition | Get-Volume
+        $mountedDrive = $mountedVHD | Get-Disk | Get-Partition | Get-Volume | Where{$_.DriveLetter}
         $letterDrive  = "$($mountedDrive.DriveLetter):\"
         Write-Verbose $letterDrive
 


### PR DESCRIPTION
On all lines containing $mountVHD | Get-Disk | Get-Partition | Get-Volume it is assumed that there is only one partition in the file. This fix makes sure partitions that does not have a drive letter, such as Recovery and System, are skipped.

A usual vhd with Windows on it has 3 partitions - Windows, System and Recovery. Only Windows will have a drive letter.