### PR TITLE
Updated to get the DriveLetter correctly... at least for VHDX files

### DIFF
--- a/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.psm1
+++ b/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
     {
         $item = GetItemToCopy -item $item
         $mountedDrive =  $mountVHD | Get-Disk | Get-Partition | Get-Volume
-        $letterDrive  = "$($mountedDrive.DriveLetter):\" 
+        $letterDrive  = (-join $mountedDrive.DriveLetter) + ":\"
        
         # show the drive letters.
         Get-PSDrive | Write-Verbose       
@@ -103,7 +103,7 @@ function Set-TargetResource
             foreach ($item in $FileDirectory)
             {
                 $itemToCopy = GetItemToCopy -item $item
-                $letterDrive = "$($mountedDrive.DriveLetter):\"
+                $letterDrive  = (-join $mountedDrive.DriveLetter) + ":\"
                 $finalDestinationPath = $letterDrive
                 $finalDestinationPath = Join-Path  $letterDrive  $itemToCopy.DestinationPath
                
@@ -186,7 +186,7 @@ function Test-TargetResource
         Get-PSDrive | Write-Verbose
 
         $mountedDrive = $mountedVHD | Get-Disk | Get-Partition | Get-Volume
-        $letterDrive  = "$($mountedDrive.DriveLetter):\"
+        $letterDrive  = (-join $mountedDrive.DriveLetter) + ":\"
         Write-Verbose $letterDrive
 
         # return test result equal to true unless one of the tests in the loop below fails.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Please see the Examples section for more details.
 
 ## Versions
 
+### Unreleased
+
+-  Fixed drive letter when mounting VHD when calling resource xVhdFile. Fixes #20.
+
 ### 3.2.0.0
 
 * Added data type System.String to CheckSum parameter of Get/Set/Test-TargetResource functions and aligned indentation.


### PR DESCRIPTION
…Drive letter was coming through with a space. So when the VHDX was mounted and it pulled the drive letter and apppended ":\" it would come through as "E :\" (with a space between the "E" and the ":". $mountedDrive.DriveLetter returns a CharArray. -join on the character array seems to remove the space at the end.

Prior to updating this I was getting the following error when trying to copy an unattend.xml file to the mounded VHDX:

Cannot find drive. A drive with the name ' E' does not exist.
    + CategoryInfo          : ObjectNotFound: ( E:) [], CimException
    + FullyQualifiedErrorId : DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand
    + PSComputerName        : localhost

Cannot bind argument to parameter 'Path' because it is null.
    + CategoryInfo          : InvalidData: (:) [], CimException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.TestPathCommand