### PR TITLE
Fixes #52

### DIFF
--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -606,10 +606,10 @@ function Get-VhdHierarchy
         [Parameter(Mandatory)]
         [System.String] $VhdPath
     )
-
+    
     $vmVhdPath = Get-VHD -Path $VhdPath
     Write-Output -InputObject $vmVhdPath.Path
-    while($vmVhdPath.ParentPath -ne [String]::Empty)
+    while(-not [System.String]::IsNullOrEmpty($vmVhdPath.ParentPath))
     {
         $vmVhdPath.ParentPath
         $vmVhdPath = (Get-VHD -Path $vmVhdPath.ParentPath)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Please see the Examples section for more details.
 
 ### Unreleased
 
+* MSFT_xVMHyperV: Fixed bug in Test-TargetResource throwing when a Vhd's ParentPath property was null.
+
 ### 3.4.0.0
 
 * MSFT_xVMHyperV: Fixed bug causing Test-TargetResource to fail when VM had snapshots.

--- a/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
+++ b/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
@@ -97,6 +97,24 @@ Describe 'xVMHyper-V' {
         }
         Mock -CommandName Get-VMIntegrationService -MockWith {return [pscustomobject]@{Enabled=$false}}
         Mock -CommandName Get-Module -ParameterFilter { ($Name -eq 'Hyper-V') -and ($ListAvailable -eq $true) } -MockWith { return $true; }
+
+        Context 'Validates Get-VhdHierarchy' {
+
+            It 'Does not throw with null parent path (#52)' {
+                
+                $fakeVhdPath = 'BaseVhd.vhdx';
+                Mock -CommandName Get-VHD -ParameterFilter { $Path -eq $fakeVhdPath } -MockWith {
+                    return [PSCustomObject] @{
+                        Path = $fakeVhdPath;
+                        ParentPath = $null;
+                    }
+                }
+
+                { Get-VhdHierarchy -VhdPath $fakeVhdPath } | Should Not Throw;
+            }
+
+        } #end context validates Get-VhdHierarchy
+
         Mock -CommandName Get-VhdHierarchy -ParameterFilter { $VhdPath.EndsWith('.vhd') } -MockWith {
             ## Return single Vhd chain for .vhds
             return @($stubVhdDisk.FullName);   

--- a/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
+++ b/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
@@ -34,6 +34,7 @@ Describe 'xVMHyper-V' {
         function Get-VMIntegrationService { param ([Parameter(ValueFromPipeline)] $VM, $Name)}
         function Enable-VMIntegrationService { param ([Parameter(ValueFromPipeline)] $VM, $Name)}
         function Disable-VMIntegrationService { param ([Parameter(ValueFromPipeline)] $VM, $name)}
+        function Get-VHD { param ( $Path ) }
 
         $stubVhdxDisk = New-Item -Path 'TestDrive:\TestVM.vhdx' -ItemType File;
         $studVhdxDiskSnapshot = New-Item -Path "TestDrive:\TestVM_D0145678-1576-4435-AB18-9F000C1C17D0.avhdx"  -ItemType File;
@@ -97,23 +98,6 @@ Describe 'xVMHyper-V' {
         }
         Mock -CommandName Get-VMIntegrationService -MockWith {return [pscustomobject]@{Enabled=$false}}
         Mock -CommandName Get-Module -ParameterFilter { ($Name -eq 'Hyper-V') -and ($ListAvailable -eq $true) } -MockWith { return $true; }
-
-        Context 'Validates Get-VhdHierarchy' {
-
-            It 'Does not throw with null parent path (#52)' {
-                
-                $fakeVhdPath = 'BaseVhd.vhdx';
-                Mock -CommandName Get-VHD -ParameterFilter { $Path -eq $fakeVhdPath } -MockWith {
-                    return [PSCustomObject] @{
-                        Path = $fakeVhdPath;
-                        ParentPath = $null;
-                    }
-                }
-
-                { Get-VhdHierarchy -VhdPath $fakeVhdPath } | Should Not Throw;
-            }
-
-        } #end context validates Get-VhdHierarchy
 
         Mock -CommandName Get-VhdHierarchy -ParameterFilter { $VhdPath.EndsWith('.vhd') } -MockWith {
             ## Return single Vhd chain for .vhds
@@ -497,6 +481,25 @@ Describe 'xVMHyper-V' {
                 Assert-MockCalled -CommandName Set-VMFirmware -Scope It;
             }
         } #end context Validates Change-VMSecureBoot Method
+
+        Context 'Validates Get-VhdHierarchy Method' {
+
+            It 'Does not throw with null parent path (#52)' {
+                
+                ## Must use a different file extension to ensure existing mocks Get-VhdHierarchy or not called
+                $fakeVhdPath = 'BaseVhd.avhdx';
+                Mock -CommandName Get-VHD -ParameterFilter { $Path -eq $fakeVhdPath } -MockWith {
+                    return [PSCustomObject] @{
+                        Path = $fakeVhdPath;
+                        ParentPath = $null;
+                    }
+                }
+
+                { Get-VhdHierarchy -VhdPath $fakeVhdPath } | Should Not Throw;
+            }
+
+        } #end context validates Get-VhdHierarchy
+
 
     } #end inmodulescope
 } #end describe xVMHyper-V


### PR DESCRIPTION
Fixed bug in Test-TargetResource throwing when a Vhd's ParentPath property was null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xhyper-v/57)
<!-- Reviewable:end -->
