### PR TITLE
Error thrown when VM resource's Ensure property equals false

### DIFF
--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -497,7 +497,7 @@ function Test-TargetResource
     }
     
     # Check if $VhdPath exist
-    if(!(Test-Path $VhdPath))
+    if(($Ensure -eq "Present") -and (!(Test-Path -Path $VhdPath)))
     {
         Throw ($localizedData.VhdPathDoesNotExistError -f $VhdPath)
     }


### PR DESCRIPTION
The VM's VHD's path was being verified when the VM resource's Ensure=false. If the VM doesn't exist, it doesn't make sense to verify that its VHD's Path is valid. The VM is going to be deleted anyway.