### PR TITLE
Test for Ensure Absent VM with missing VHD

### DIFF
--- a/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
+++ b/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
@@ -155,16 +155,16 @@ Describe 'xVMHyper-V' {
                 Test-TargetResource -Name 'NonexistentVM' -Ensure Absent @testParams | Should Be $true;
             }
             
-            It 'Returns $true when VM is not present, "Ensure" = "Absent", and the VHD file path does not exist' {	    
-	    	$targetVHDPath = 'TestDrive:\TestVHDNotExist.vhdx'
-		
-		# Verify that the arbitrary VHD path doesn't exist
-		if (Test-Path -Path $targetVHDPath) { Remove-Item -Path $targetVHDPath }
-		
-		$testParamsLocal = @{
-			VhdPath = $targetVHDPath;
-		}
-		Test-TargetResource -Name 'NonexistentVM' -Ensure Absent $testParamsLocal | Should Be $true;
+            It 'Returns $true when VM is not present, "Ensure" = "Absent", and the VHD file path does not exist' {
+                $targetVHDPath = 'TestDrive:\TestVHDNotExist.vhdx'
+                
+                # Verify that the arbitrary VHD path doesn't exist
+                if (Test-Path -Path $targetVHDPath) { Remove-Item -Path $targetVHDPath }
+                
+                $testParamsLocal = @{
+                        VhdPath = $targetVHDPath;
+                }
+                Test-TargetResource -Name 'NonexistentVM' -Ensure Absent $testParamsLocal | Should Be $true;
             }
 
             It 'Returns $false when VM is present and "Ensure" = "Absent"' {

--- a/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
+++ b/Tests/MSFT_xVMHyper-V/xVMHyper-V.Tests.ps1
@@ -154,6 +154,18 @@ Describe 'xVMHyper-V' {
             It 'Returns $true when VM is not present and "Ensure" = "Absent"' {
                 Test-TargetResource -Name 'NonexistentVM' -Ensure Absent @testParams | Should Be $true;
             }
+            
+            It 'Returns $true when VM is not present, "Ensure" = "Absent", and the VHD file path does not exist' {
+				$targetVHDPath = 'TestDrive:\TestVHDNotExist.vhdx'
+				
+				# Verify that the arbitrary VHD path doesn't exist
+				if (Test-Path -Path $targetVHDPath) { Remove-Item -Path $targetVHDPath }
+				
+				$testParamsLocal = @{
+					VhdPath = $targetVHDPath;
+				}
+				Test-TargetResource -Name 'NonexistentVM' -Ensure Absent $testParamsLocal | Should Be $true;
+            }
 
             It 'Returns $false when VM is present and "Ensure" = "Absent"' {
                 Test-TargetResource -Name 'RunningVM' -Ensure Absent @testParams | Should Be $false;


### PR DESCRIPTION
When ensuring the VM doesn't exist, the VHD file's path shouldn't be tested. The VM is missing as desired, no more validation necessary.
Error thrown when VM resource's Ensure property equals false #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xhyper-v/69)
<!-- Reviewable:end -->
