### PR TITLE
Increase xVMHyperV VM guest StartupMemory max limit and MinimumMemory max limit from 17GB to 64GB

### DIFF
--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -447,11 +447,11 @@ function Test-TargetResource
         [UInt32]$Generation = 1,
 
         # Startup RAM for the VM
-        [ValidateRange(32MB,17342MB)]
+        [ValidateRange(32MB,65536MB)]
         [UInt64]$StartupMemory,
 
         # Minimum RAM for the VM. This enables dynamic memory
-        [ValidateRange(32MB,17342MB)]
+        [ValidateRange(32MB,65536MB)]
         [UInt64]$MinimumMemory,
 
         # Maximum RAM for the VM. This enables dynamic memory

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -124,11 +124,11 @@ function Set-TargetResource
         [UInt32]$Generation = 1,
 
         # Startup RAM for the VM
-        [ValidateRange(32MB,17342MB)]
+        [ValidateRange(32MB,65536MB)]
         [UInt64]$StartupMemory,
 
         # Minimum RAM for the VM. This enables dynamic memory
-        [ValidateRange(32MB,17342MB)]
+        [ValidateRange(32MB,65536MB)]
         [UInt64]$MinimumMemory,
 
         # Maximum RAM for the VM. This enables dynamic memory

--- a/README.md
+++ b/README.md
@@ -120,14 +120,13 @@ Please see the Examples section for more details.
 ### Unreleased
 
 * Adding a new xVMHost resource for managing Hyper-V host settings.
+* MSFT_xVMHyperV: EnableGuestService works on localized OS (language independent) 
 * Increased xVMHyperV StartupMemory and MinimumMemory limits from 17GB to 64GB.
 
 ### 3.8.0.0
 
 * Fix bug in xVMDvdDrive with hardcoded VM Name.
 * Corrected Markdown rule violations in Readme.md.
-* MSFT_xVMHyperV
-    - EnableGuestService works on localized OS (language independent)
 
 ### 3.7.0.0
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Please see the Examples section for more details.
 
 * Fix bug in xVMDvdDrive with hardcoded VM Name.
 * Corrected Markdown rule violations in Readme.md.
+* Increased xVMHyperV StartupMemory and MinimumMemory limits from 17GB to 64GB.
 
 ### 3.7.0.0
 


### PR DESCRIPTION
Fixes [#93](https://github.com/PowerShell/xHyper-V/issues/93)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xhyper-v/94)
<!-- Reviewable:end -->
