### PR TITLE
xHyper-V - Enable / disable dynamic memory for client and server SKUs in identical way (fix for issue89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * MSFT_xVMHyperV:
+  * Enable / disable dynamic memory for client and server SKUs in identical way.
   * Increased xVMHyperV StartupMemory and MinimumMemory limits from 17GB to 64GB.
   * EnableGuestService works on localized OS (language independent).
   * Adds missing Hyper-V-PowerShell feature in examples.

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -75,10 +75,10 @@ function Get-TargetResource
     }
 
     $guestServiceId = 'Microsoft:{0}\6C09BB55-D683-4DA0-8931-C9BF705F6480' -f $vmObj.Id
-    
+
     @{
         Name               = $Name
-        ## Return the Vhd specified if it exists in the Vhd chain
+        # Return the Vhd specified if it exists in the Vhd chain
         VhdPath            = if ($vhdChain -contains $VhdPath) { $VhdPath };
         SwitchName         = $vmObj.NetworkAdapters.SwitchName
         State              = $vmobj.State
@@ -238,34 +238,34 @@ function Set-TargetResource
             if ($PSBoundParameters.ContainsKey('StartupMemory') -and ($vmObj.MemoryStartup -ne $StartupMemory))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MemoryStartup', $StartupMemory, $vmObj.MemoryStartup)
-                $changeProperty["MemoryStartup"]=$StartupMemory
+                $changeProperty["MemoryStartup"] = $StartupMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($vmObj.MemoryStartup -lt $MinimumMemory))
             {
                 Write-Verbose -Message ($localizedData.AdjustingLessThanMemoryWarning -f 'StartupMemory', $vmObj.MemoryStartup, 'MinimumMemory', $MinimumMemory)
-                $changeProperty["MemoryStartup"]=$MinimumMemory
+                $changeProperty["MemoryStartup"] = $MinimumMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($vmObj.MemoryStartup -gt $MaximumMemory))
             {
                 Write-Verbose -Message ($localizedData.AdjustingGreaterThanMemoryWarning -f 'StartupMemory', $vmObj.MemoryStartup, 'MaximumMemory', $MaximumMemory)
-                $changeProperty["MemoryStartup"]=$MaximumMemory
+                $changeProperty["MemoryStartup"] = $MaximumMemory
             }
 
             # If the VM does not have the right minimum or maximum memory, stop the VM, set the right memory, start the VM
             if ($PSBoundParameters.ContainsKey('MinimumMemory') -or $PSBoundParameters.ContainsKey('MaximumMemory'))
             {
-                $changeProperty["DynamicMemory"]=$true
-                $changeProperty["StaticMemory"]=$false
+                $changeProperty["DynamicMemory"] = $true
+                $changeProperty["StaticMemory"] = $false
 
                 if ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($vmObj.Memoryminimum -ne $MinimumMemory))
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MinimumMemory', $MinimumMemory, $vmObj.MemoryMinimum)
-                    $changeProperty["MemoryMinimum"]=$MinimumMemory
+                    $changeProperty["MemoryMinimum"] = $MinimumMemory
                 }
                 if ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($vmObj.Memorymaximum -ne $MaximumMemory))
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MaximumMemory', $MaximumMemory, $vmObj.MemoryMaximum)
-                    $changeProperty["MemoryMaximum"]=$MaximumMemory
+                    $changeProperty["MemoryMaximum"] = $MaximumMemory
                 }
             }
 
@@ -273,7 +273,7 @@ function Set-TargetResource
             if ($PSBoundParameters.ContainsKey('ProcessorCount') -and ($vmObj.ProcessorCount -ne $ProcessorCount))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'ProcessorCount', $ProcessorCount, $vmObj.ProcessorCount)
-                $changeProperty["ProcessorCount"]=$ProcessorCount
+                $changeProperty["ProcessorCount"] = $ProcessorCount
             }
 
             # Stop the VM, set the right properties, start the VM only if there are properties to change
@@ -283,17 +283,19 @@ function Set-TargetResource
                 Write-Verbose -Message ($localizedData.VMPropertiesUpdated -f $Name)
             }
 
-            # Special cases to disable dynamic memory:
-            # - If startup, minimum and maximum memory are specified with equal values -or
-            # - If only startup memory is specified, but neither minimum nor maximum
+            <#
+                Special cases to disable dynamic memory:
+                - If startup, minimum and maximum memory are specified with equal values or
+                - If only startup memory is specified, but neither minimum nor maximum
+            #>
             if ( ($PSBoundParameters.ContainsKey('StartupMemory') -and
-                   ($StartupMemory -eq $MinimumMemory) -and 
-                   ($StartupMemory -eq $MaximumMemory) 
+                   ($StartupMemory -eq $MinimumMemory) -and
+                   ($StartupMemory -eq $MaximumMemory)
                  ) -or
                  ( $PSBoundParameters.ContainsKey('StartupMemory') -and
-                   (-not $PSBoundParameters.ContainsKey('MinimumMemory')) -and 
-                   (-not $PSBoundParameters.ContainsKey('MaximumMemory')) 
-                 ) 
+                   (-not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
+                   (-not $PSBoundParameters.ContainsKey('MaximumMemory'))
+                 )
                )
             {
                 # Refresh VM properties
@@ -305,24 +307,24 @@ function Set-TargetResource
                         VMName = $Name
                         VMCommand = 'Set-VM'
                         ChangeProperty = @{
-                            StaticMemory = $true 
+                            StaticMemory = $true
                             DynamicMemory = $false
-                            }
+                        }
                         WaitForIP = $WaitForIP
                         RestartIfNeeded = $RestartIfNeeded
-                        }
+                    }
                     Set-VMProperty @setVMPropertyParams
                     Write-Verbose -Message ($localizedData.VMPropertiesUpdated -f $Name)
                 }
             }
 
-            ## Set VM network switches. This can be done while the VM is running.
+            # Set VM network switches. This can be done while the VM is running.
             for ($i = 0; $i -lt $SwitchName.Count; $i++)
             {
                 $switch = $SwitchName[$i]
                 $nic = $vmObj.NetworkAdapters[$i]
                 if ($nic) {
-                    ## We cannot change the MAC address whilst the VM is running.. This is changed later
+                    # We cannot change the MAC address whilst the VM is running.. This is changed later
                     if ($nic.SwitchName -ne $switch) {
                         Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'NIC', $switch, $nic.SwitchName)
                         $nic | Connect-VMNetworkAdapter -SwitchName $switch
@@ -341,7 +343,7 @@ function Set-TargetResource
                         Add-VMNetworkAdapter -VMName $Name -SwitchName $switch
                         Write-Verbose -Message ($localizedData.VMPropertySet -f 'NIC', $switch)
                     }
-                    ## Refresh the NICs after we've added one
+                    # Refresh the NICs after we've added one
                     $vmObj = Get-VM -Name $Name -ErrorAction SilentlyContinue
                 }
             }
@@ -430,24 +432,24 @@ function Set-TargetResource
             # Optional parameters
             if ($SwitchName)
             {
-                $parameters["SwitchName"]=$SwitchName[0]
+                $parameters["SwitchName"] = $SwitchName[0]
             }
             if ($Path)
             {
-                $parameters["Path"]=$Path
+                $parameters["Path"] = $Path
             }
             $defaultStartupMemory = 512MB
             if ($PSBoundParameters.ContainsKey('StartupMemory'))
             {
-                $parameters["MemoryStartupBytes"]=$StartupMemory
+                $parameters["MemoryStartupBytes"] = $StartupMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($defaultStartupMemory -lt $MinimumMemory))
             {
-                $parameters["MemoryStartupBytes"]=$MinimumMemory
+                $parameters["MemoryStartupBytes"] = $MinimumMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($defaultStartupMemory -gt $MaximumMemory))
             {
-                $parameters["MemoryStartupBytes"]=$MaximumMemory
+                $parameters["MemoryStartupBytes"] = $MaximumMemory
             }
             $null = New-VM @parameters
 
@@ -483,19 +485,19 @@ function Set-TargetResource
 
             # Special case: Disable dynamic memory if startup, minimum and maximum memory are equal
             if ($PSBoundParameters.ContainsKey('StartupMemory') -and
-                ($StartupMemory -eq $MinimumMemory) -and 
+                ($StartupMemory -eq $MinimumMemory) -and
                 ($StartupMemory -eq $MaximumMemory))
             {
                 Set-VMMemory -VMName $Name -DynamicMemoryEnabled $false
             }
 
-            ## There's always a NIC added with New-VM
+            # There's always a NIC added with New-VM
             if ($MACAddress)
             {
                 Set-VMNetworkAdapter -VMName $Name -StaticMacAddress $MACAddress[0]
             }
 
-            ## Add additional NICs
+            # Add additional NICs
             for ($i = 1; $i -lt $SwitchName.Count; $i++)
             {
                 $addVMNetworkAdapterParams = @{
@@ -654,24 +656,24 @@ function Test-TargetResource
     }
 
     # Check if Minimum memory is less than StartUpmemory
-    if ($PSBoundParameters.ContainsKey('StartupMemory') -and 
-        $PSBoundParameters.ContainsKey('MinimumMemory') -and  
+    if ($PSBoundParameters.ContainsKey('StartupMemory') -and
+        $PSBoundParameters.ContainsKey('MinimumMemory') -and
         ($MinimumMemory -gt $StartupMemory))
     {
         Throw ($localizedData.MinMemGreaterThanStartupMemError -f $MinimumMemory, $StartupMemory)
     }
 
     # Check if Minimum memory is greater than Maximummemory
-    if ($PSBoundParameters.ContainsKey('MaximumMemory') -and 
-        $PSBoundParameters.ContainsKey('MinimumMemory') -and 
+    if ($PSBoundParameters.ContainsKey('MaximumMemory') -and
+        $PSBoundParameters.ContainsKey('MinimumMemory') -and
         ($MinimumMemory -gt $MaximumMemory))
     {
         Throw ($localizedData.MinMemGreaterThanMaxMemError -f $MinimumMemory, $MaximumMemory)
     }
 
     # Check if Startup memory is greater than Maximummemory
-    if ($PSBoundParameters.ContainsKey('MaximumMemory') -and 
-        $PSBoundParameters.ContainsKey('StartupMemory') -and 
+    if ($PSBoundParameters.ContainsKey('MaximumMemory') -and
+        $PSBoundParameters.ContainsKey('StartupMemory') -and
         ($StartupMemory -gt $MaximumMemory))
     {
         Throw ($localizedData.StartUpMemGreaterThanMaxMemError -f $StartupMemory, $MaximumMemory)
@@ -703,46 +705,46 @@ function Test-TargetResource
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'VhdPath', $VhdPath, ($vhdChain -join ','))
                 return $false
             }
-            if ($state -and ($vmObj.State -ne $State)) 
+            if ($state -and ($vmObj.State -ne $State))
             {
                 return $false
             }
-            if ($PSBoundParameters.ContainsKey('StartupMemory') -and 
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and
                 ($vmObj.MemoryStartup -ne $StartupMemory))
             {
                 return $false
             }
-            if ($PSBoundParameters.ContainsKey('MaximumMemory') -and 
+            if ($PSBoundParameters.ContainsKey('MaximumMemory') -and
                 ($vmObj.MemoryMaximum -ne $MaximumMemory))
             {
                 return $false
             }
-            if ($PSBoundParameters.ContainsKey('MinimumMemory') -and 
-                ($vmObj.MemoryMinimum -ne $MinimumMemory)) 
+            if ($PSBoundParameters.ContainsKey('MinimumMemory') -and
+                ($vmObj.MemoryMinimum -ne $MinimumMemory))
             {
                 return $false
             }
             # If startup memory but neither minimum nor maximum memory specified, dynamic memory should be disabled
-            if ($PSBoundParameters.ContainsKey('$StartupMemory') -and 
-               ( -not $PSBoundParameters.ContainsKey('MinimumMemory')) -and 
-               ( -not $PSBoundParameters.ContainsKey('MaximumMemory')) -and 
-               $vmobj.DynamicMemoryEnabled) 
+            if ($PSBoundParameters.ContainsKey('$StartupMemory') -and
+               ( -not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
+               ( -not $PSBoundParameters.ContainsKey('MaximumMemory')) -and
+               $vmobj.DynamicMemoryEnabled)
             {
                 return $false
             }
-            
-            # If startup, minimum and maximum memory are specified with the same values
-            if ($PSBoundParameters.ContainsKey('StartupMemory') -and 
-                $PSBoundParameters.ContainsKey('MinimumMemory') -and 
-                $PSBoundParameters.ContainsKey('MaximumMemory') -and 
-                ($StartupMemory -eq $MinimumMemory) -and 
+
+            # If startup, minimum and maximum memory are specified with the same values, dynamic memory should be disabled
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and
+                $PSBoundParameters.ContainsKey('MinimumMemory') -and
+                $PSBoundParameters.ContainsKey('MaximumMemory') -and
+                ($StartupMemory -eq $MinimumMemory) -and
                 ($StartupMemory -eq $MaximumMemory) -and
                 $vmobj.DynamicMemoryEnabled)
             {
                 return $false
             }
 
-            if ($vmObj.HardDrives.Path -notcontains $VhdPath) 
+            if ($vmObj.HardDrives.Path -notcontains $VhdPath)
             {
                 return $false
             }
@@ -763,13 +765,13 @@ function Test-TargetResource
                 }
             }
 
-            ## $Generation always exists, only check if parameter has been explicitly specified
-            if ($PSBoundParameters.ContainsKey('Generation') -and ($Generation -ne $vmObj.Generation)) 
+            # $Generation always exists, only check if parameter has been explicitly specified
+            if ($PSBoundParameters.ContainsKey('Generation') -and ($Generation -ne $vmObj.Generation))
             {
                 return $false
             }
 
-            if ($PSBoundParameters.ContainsKey('ProcessorCount') -and ($vmObj.ProcessorCount -ne $ProcessorCount)) 
+            if ($PSBoundParameters.ContainsKey('ProcessorCount') -and ($vmObj.ProcessorCount -ne $ProcessorCount))
             {
                 return $false
             }

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -50,7 +50,7 @@ function Get-TargetResource
     )
 
     # Check if Hyper-V module is present for Hyper-V cmdlets
-    if(!(Get-Module -ListAvailable -Name Hyper-V))
+    if (!(Get-Module -ListAvailable -Name Hyper-V))
     {
         Throw ($localizedData.RoleMissingError -f 'Hyper-V')
     }
@@ -58,7 +58,7 @@ function Get-TargetResource
     $vmobj = Get-VM -Name $Name -ErrorAction SilentlyContinue
 
     # Check if 1 or 0 VM with name = $name exist
-    if($vmobj.count -gt 1)
+    if ($vmobj.count -gt 1)
     {
        Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
     }
@@ -90,7 +90,7 @@ function Get-TargetResource
         MaximumMemory      = $vmobj.MemoryMaximum
         MACAddress         = $vmObj.NetWorkAdapters.MacAddress
         ProcessorCount     = $vmobj.ProcessorCount
-        Ensure             = if($vmobj){"Present"}else{"Absent"}
+        Ensure             = if ($vmobj){"Present"} else {"Absent"}
         ID                 = $vmobj.Id
         Status             = $vmobj.Status
         CPUUsage           = $vmobj.CPUUsage
@@ -200,7 +200,7 @@ function Set-TargetResource
     )
 
     # Check if Hyper-V module is present for Hyper-V cmdlets
-    if(!(Get-Module -ListAvailable -Name Hyper-V))
+    if (!(Get-Module -ListAvailable -Name Hyper-V))
     {
         Throw ($localizedData.RoleMissingError -f 'Hyper-V')
     }
@@ -209,12 +209,12 @@ function Set-TargetResource
     $vmObj = Get-VM -Name $Name -ErrorAction SilentlyContinue
 
     # VM already exists
-    if($vmObj)
+    if ($vmObj)
     {
         Write-Verbose -Message ($localizedData.VMExists -f $Name)
 
         # If VM shouldn't be there, stop it and remove it
-        if($Ensure -eq "Absent")
+        if ($Ensure -eq "Absent")
         {
             Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'Ensure', $Ensure, 'Present')
             Get-VM $Name | Stop-VM -Force -Passthru -WarningAction SilentlyContinue | Remove-VM -Force
@@ -226,7 +226,7 @@ function Set-TargetResource
         else
         {
             # If state has been specified and the VM is not in right state, set it to right state
-            if($State -and ($vmObj.State -ne $State))
+            if ($State -and ($vmObj.State -ne $State))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'State', $State, $vmObj.State)
                 Set-VMState -Name $Name -State $State -WaitForIP $WaitForIP
@@ -235,34 +235,34 @@ function Set-TargetResource
 
             $changeProperty = @{}
             # If the VM does not have the right startup memory
-            if($StartupMemory -and ($vmObj.MemoryStartup -ne $StartupMemory))
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and ($vmObj.MemoryStartup -ne $StartupMemory))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MemoryStartup', $StartupMemory, $vmObj.MemoryStartup)
                 $changeProperty["MemoryStartup"]=$StartupMemory
             }
-            elseif($MinimumMemory -and ($vmObj.MemoryStartup -lt $MinimumMemory))
+            elseif ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($vmObj.MemoryStartup -lt $MinimumMemory))
             {
                 Write-Verbose -Message ($localizedData.AdjustingLessThanMemoryWarning -f 'StartupMemory', $vmObj.MemoryStartup, 'MinimumMemory', $MinimumMemory)
                 $changeProperty["MemoryStartup"]=$MinimumMemory
             }
-            elseif($MaximumMemory -and ($vmObj.MemoryStartup -gt $MaximumMemory))
+            elseif ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($vmObj.MemoryStartup -gt $MaximumMemory))
             {
                 Write-Verbose -Message ($localizedData.AdjustingGreaterThanMemoryWarning -f 'StartupMemory', $vmObj.MemoryStartup, 'MaximumMemory', $MaximumMemory)
                 $changeProperty["MemoryStartup"]=$MaximumMemory
             }
 
             # If the VM does not have the right minimum or maximum memory, stop the VM, set the right memory, start the VM
-            if($MinimumMemory -or $MaximumMemory)
+            if ($PSBoundParameters.ContainsKey('MinimumMemory') -or $PSBoundParameters.ContainsKey('MaximumMemory'))
             {
                 $changeProperty["DynamicMemory"]=$true
                 $changeProperty["StaticMemory"]=$false
 
-                if($MinimumMemory -and ($vmObj.Memoryminimum -ne $MinimumMemory))
+                if ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($vmObj.Memoryminimum -ne $MinimumMemory))
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MinimumMemory', $MinimumMemory, $vmObj.MemoryMinimum)
                     $changeProperty["MemoryMinimum"]=$MinimumMemory
                 }
-                if($MaximumMemory -and ($vmObj.Memorymaximum -ne $MaximumMemory))
+                if ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($vmObj.Memorymaximum -ne $MaximumMemory))
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MaximumMemory', $MaximumMemory, $vmObj.MemoryMaximum)
                     $changeProperty["MemoryMaximum"]=$MaximumMemory
@@ -270,7 +270,7 @@ function Set-TargetResource
             }
 
             # If the VM does not have the right processor count, stop the VM, set the right memory, start the VM
-            if($ProcessorCount -and ($vmObj.ProcessorCount -ne $ProcessorCount))
+            if ($PSBoundParameters.ContainsKey('ProcessorCount') -and ($vmObj.ProcessorCount -ne $ProcessorCount))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'ProcessorCount', $ProcessorCount, $vmObj.ProcessorCount)
                 $changeProperty["ProcessorCount"]=$ProcessorCount
@@ -284,14 +284,15 @@ function Set-TargetResource
             }
 
             # Special cases to disable dynamic memory:
-            # - If startup, minimum and maximum memory are equal but not null -or
+            # - If startup, minimum and maximum memory are specified with equal values -or
             # - If only startup memory is specified, but neither minimum nor maximum
-            if ( ( $StartupMemory -and
+            if ( ($PSBoundParameters.ContainsKey('StartupMemory') -and
                    ($StartupMemory -eq $MinimumMemory) -and 
                    ($StartupMemory -eq $MaximumMemory) 
                  ) -or
-                 ( $StartupMemory -and
-                   (-not $MinimumMemory) -and (-not $MaximumMemory) 
+                 ( $PSBoundParameters.ContainsKey('StartupMemory') -and
+                   (-not $PSBoundParameters.ContainsKey('MinimumMemory')) -and 
+                   (-not $PSBoundParameters.ContainsKey('MaximumMemory')) 
                  ) 
                )
             {
@@ -300,10 +301,17 @@ function Set-TargetResource
                 if ($vmObj.DynamicMemoryEnabled)
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'DynamicMemoryEnabled', $false, $vmObj.DynamicMemoryEnabled)
-                    $changeProperty = @{}
-                    $changeProperty["StaticMemory"]=$true
-                    $changeProperty["DynamicMemory"]=$false
-                    Set-VMProperty -Name $Name -VMCommand "Set-VM" -ChangeProperty $changeProperty -WaitForIP $WaitForIP -RestartIfNeeded $RestartIfNeeded
+                    $setVMPropertyParams = @{
+                        VMName = $Name
+                        VMCommand = 'Set-VM'
+                        ChangeProperty = @{
+                            StaticMemory = $true 
+                            DynamicMemory = $false
+                            }
+                        WaitForIP = $WaitForIP
+                        RestartIfNeeded = $RestartIfNeeded
+                        }
+                    Set-VMProperty @setVMPropertyParams
                     Write-Verbose -Message ($localizedData.VMPropertiesUpdated -f $Name)
                 }
             }
@@ -378,10 +386,10 @@ function Set-TargetResource
                 }
             }
 
-            if($Notes -ne $null)
+            if ($Notes -ne $null)
             {
                 # If the VM notes do not match the desire notes, update them.  This can be done while the VM is running.
-                if($vmObj.Notes -ne $Notes)
+                if ($vmObj.Notes -ne $Notes)
                 {
                     Set-Vm -Name $Name -Notes $Notes
                 }
@@ -410,7 +418,7 @@ function Set-TargetResource
     else
     {
         Write-Verbose -Message ($localizedData.VMDoesNotExist -f $Name)
-        if($Ensure -eq "Present")
+        if ($Ensure -eq "Present")
         {
             Write-Verbose -Message ($localizedData.CreatingVM -f $Name)
 
@@ -420,43 +428,61 @@ function Set-TargetResource
             $parameters["Generation"] = $Generation
 
             # Optional parameters
-            if($SwitchName)
+            if ($SwitchName)
             {
                 $parameters["SwitchName"]=$SwitchName[0]
             }
-            if($Path){$parameters["Path"]=$Path}
+            if ($Path)
+            {
+                $parameters["Path"]=$Path
+            }
             $defaultStartupMemory = 512MB
-            if($StartupMemory){$parameters["MemoryStartupBytes"]=$StartupMemory}
-            elseif($MinimumMemory -and $defaultStartupMemory -lt $MinimumMemory){$parameters["MemoryStartupBytes"]=$MinimumMemory}
-            elseif($MaximumMemory -and $defaultStartupMemory -gt $MaximumMemory){$parameters["MemoryStartupBytes"]=$MaximumMemory}
+            if ($PSBoundParameters.ContainsKey('StartupMemory'))
+            {
+                $parameters["MemoryStartupBytes"]=$StartupMemory
+            }
+            elseif ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($defaultStartupMemory -lt $MinimumMemory))
+            {
+                $parameters["MemoryStartupBytes"]=$MinimumMemory
+            }
+            elseif ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($defaultStartupMemory -gt $MaximumMemory))
+            {
+                $parameters["MemoryStartupBytes"]=$MaximumMemory
+            }
             $null = New-VM @parameters
 
             $parameters = @{}
             $parameters["Name"] = $Name
-            $parameters["StaticMemory"]=$true
-            $parameters["DynamicMemory"]=$false
-            if ($MinimumMemory -or $MaximumMemory)
+            $parameters["StaticMemory"] = $true
+            $parameters["DynamicMemory"] = $false
+            if ($PSBoundParameters.ContainsKey('MinimumMemory') -or $PSBoundParameters.ContainsKey('MaximumMemory'))
             {
-                $parameters["DynamicMemory"]=$true
-                $parameters["StaticMemory"]=$false
-                if($MinimumMemory){$parameters["MemoryMinimumBytes"]=$MinimumMemory}
-                if($MaximumMemory){$parameters["MemoryMaximumBytes"]=$MaximumMemory}
+                $parameters["DynamicMemory"] = $true
+                $parameters["StaticMemory"] = $false
+                if ($PSBoundParameters.ContainsKey('MinimumMemory'))
+                {
+                    $parameters["MemoryMinimumBytes"] = $MinimumMemory
+                }
+                if ($PSBoundParameters.ContainsKey('MaximumMemory'))
+                {
+                    $parameters["MemoryMaximumBytes"] = $MaximumMemory
+                }
             }
 
-            if($Notes)
+            if ($Notes)
             {
                 $parameters["Notes"] = $Notes
             }
 
-            if($ProcessorCount)
+            if ($PSBoundParameters.ContainsKey('ProcessorCount'))
             {
-                $parameters["ProcessorCount"]=$ProcessorCount
+                $parameters["ProcessorCount"] = $ProcessorCount
             }
 
             $null = Set-VM @parameters
 
-            # Special case: Disable dynamic memory if startup, minimum and maximum memory are equal but not null
-            if( $StartupMemory -and
+            # Special case: Disable dynamic memory if startup, minimum and maximum memory are equal
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and
                 ($StartupMemory -eq $MinimumMemory) -and 
                 ($StartupMemory -eq $MaximumMemory))
             {
@@ -464,7 +490,7 @@ function Set-TargetResource
             }
 
             ## There's always a NIC added with New-VM
-            if($MACAddress)
+            if ($MACAddress)
             {
                 Set-VMNetworkAdapter -VMName $Name -StaticMacAddress $MACAddress[0]
             }
@@ -610,50 +636,56 @@ function Test-TargetResource
     #region input validation
 
     # Check if Hyper-V module is present for Hyper-V cmdlets
-    if(!(Get-Module -ListAvailable -Name Hyper-V))
+    if (!(Get-Module -ListAvailable -Name Hyper-V))
     {
         Throw ($localizedData.RoleMissingError -f 'Hyper-V')
     }
 
     # Check if 1 or 0 VM with name = $name exist
-    if((Get-VM -Name $Name -ErrorAction SilentlyContinue).count -gt 1)
+    if ((Get-VM -Name $Name -ErrorAction SilentlyContinue).count -gt 1)
     {
        Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
     }
 
     # Check if $VhdPath exist
-    if(!(Test-Path $VhdPath))
+    if (!(Test-Path $VhdPath))
     {
         Throw ($localizedData.VhdPathDoesNotExistError -f $VhdPath)
     }
 
     # Check if Minimum memory is less than StartUpmemory
-    if($StartupMemory -and $MinimumMemory -and  ($MinimumMemory -gt $StartupMemory))
+    if ($PSBoundParameters.ContainsKey('StartupMemory') -and 
+        $PSBoundParameters.ContainsKey('MinimumMemory') -and  
+        ($MinimumMemory -gt $StartupMemory))
     {
         Throw ($localizedData.MinMemGreaterThanStartupMemError -f $MinimumMemory, $StartupMemory)
     }
 
     # Check if Minimum memory is greater than Maximummemory
-    if($MaximumMemory -and $MinimumMemory -and ($MinimumMemory -gt $MaximumMemory))
+    if ($PSBoundParameters.ContainsKey('MaximumMemory') -and 
+        $PSBoundParameters.ContainsKey('MinimumMemory') -and 
+        ($MinimumMemory -gt $MaximumMemory))
     {
         Throw ($localizedData.MinMemGreaterThanMaxMemError -f $MinimumMemory, $MaximumMemory)
     }
 
     # Check if Startup memory is greater than Maximummemory
-    if($MaximumMemory -and $StartupMemory -and ($StartupMemory -gt $MaximumMemory))
+    if ($PSBoundParameters.ContainsKey('MaximumMemory') -and 
+        $PSBoundParameters.ContainsKey('StartupMemory') -and 
+        ($StartupMemory -gt $MaximumMemory))
     {
         Throw ($localizedData.StartUpMemGreaterThanMaxMemError -f $StartupMemory, $MaximumMemory)
     }
 
     <#  VM Generation has no direct relation to the virtual hard disk format and cannot be changed
         after the virtual machine has been created. Generation 2 VMs do not support .VHD files.  #>
-    if(($Generation -eq 2) -and ($VhdPath.Split('.')[-1] -eq 'vhd'))
+    if (($Generation -eq 2) -and ($VhdPath.Split('.')[-1] -eq 'vhd'))
     {
         Throw ($localizedData.VhdUnsupportedOnGen2VMError)
     }
 
     # Check if $Path exist
-    if($Path -and !(Test-Path -Path $Path))
+    if ($Path -and !(Test-Path -Path $Path))
     {
         Throw ($localizedData.PathDoesNotExistError -f $Path)
     }
@@ -663,37 +695,57 @@ function Test-TargetResource
     try
     {
         $vmObj = Get-VM -Name $Name -ErrorAction Stop
-        if($Ensure -eq "Present")
+        if ($Ensure -eq "Present")
         {
             $vhdChain = @(Get-VhdHierarchy -VhdPath ($vmObj.HardDrives[0].Path))
-            if($vhdChain -notcontains $VhdPath)
+            if ($vhdChain -notcontains $VhdPath)
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'VhdPath', $VhdPath, ($vhdChain -join ','))
                 return $false
             }
-            if($state -and ($vmObj.State -ne $State)){return $false}
-            if($StartupMemory -and ($vmObj.MemoryStartup -ne $StartupMemory)){return $false}
-            if($MaximumMemory -and ($vmObj.MemoryMaximum -ne $MaximumMemory)){return $false}
-            if($MinimumMemory -and ($vmObj.MemoryMinimum -ne $MinimumMemory)){return $false}
+            if ($state -and ($vmObj.State -ne $State)) 
+            {
+                return $false
+            }
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and 
+                ($vmObj.MemoryStartup -ne $StartupMemory))
+            {
+                return $false
+            }
+            if ($PSBoundParameters.ContainsKey('MaximumMemory') -and 
+                ($vmObj.MemoryMaximum -ne $MaximumMemory))
+            {
+                return $false
+            }
+            if ($PSBoundParameters.ContainsKey('MinimumMemory') -and 
+                ($vmObj.MemoryMinimum -ne $MinimumMemory)) 
+            {
+                return $false
+            }
             # If startup memory but neither minimum nor maximum memory specified, dynamic memory should be disabled
-            if ($StartupMemory -and 
-               ( -not $MinimumMemory) -and 
-               ( -not $MaximumMemory) -and 
+            if ($PSBoundParameters.ContainsKey('$StartupMemory') -and 
+               ( -not $PSBoundParameters.ContainsKey('MinimumMemory')) -and 
+               ( -not $PSBoundParameters.ContainsKey('MaximumMemory')) -and 
                $vmobj.DynamicMemoryEnabled) 
             {
                 return $false
             }
             
-            # If startup, minimum and maximum memory are equal but not null, dynamic memory should be disabled
-            If($StartupMemory -and 
-               ($StartupMemory -eq $MinimumMemory) -and 
-               ($StartupMemory -eq $MaximumMemory) -and
-               $vmobj.DynamicMemoryEnabled)
+            # If startup, minimum and maximum memory are specified with the same values
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and 
+                $PSBoundParameters.ContainsKey('MinimumMemory') -and 
+                $PSBoundParameters.ContainsKey('MaximumMemory') -and 
+                ($StartupMemory -eq $MinimumMemory) -and 
+                ($StartupMemory -eq $MaximumMemory) -and
+                $vmobj.DynamicMemoryEnabled)
             {
                 return $false
             }
 
-            if($vmObj.HardDrives.Path -notcontains $VhdPath){return $false}
+            if ($vmObj.HardDrives.Path -notcontains $VhdPath) 
+            {
+                return $false
+            }
             for ($i = 0; $i -lt $SwitchName.Count; $i++)
             {
                 if ($vmObj.NetworkAdapters[$i].SwitchName -ne $SwitchName[$i])
@@ -712,11 +764,17 @@ function Test-TargetResource
             }
 
             ## $Generation always exists, only check if parameter has been explicitly specified
-            if($PSBoundParameters.ContainsKey('Generation') -and ($Generation -ne $vmObj.Generation)){return $false}
+            if ($PSBoundParameters.ContainsKey('Generation') -and ($Generation -ne $vmObj.Generation)) 
+            {
+                return $false
+            }
 
-            if($ProcessorCount -and ($vmObj.ProcessorCount -ne $ProcessorCount)){return $false}
+            if ($PSBoundParameters.ContainsKey('ProcessorCount') -and ($vmObj.ProcessorCount -ne $ProcessorCount)) 
+            {
+                return $false
+            }
 
-            if($vmObj.Generation -eq 2) {
+            if ($vmObj.Generation -eq 2) {
                 $vmSecureBoot = Test-VMSecureBoot -Name $Name
                 if ($SecureBoot -ne $vmSecureBoot)
                 {
@@ -793,24 +851,24 @@ function Set-VMMACAddress
     )
     $vmObj = Get-VM -Name $Name
     $originalState = $vmObj.state
-    if($originalState -ne "Off" -and $RestartIfNeeded)
+    if ($originalState -ne "Off" -and $RestartIfNeeded)
     {
         Set-VMState -Name $Name -State Off
         $vmObj.NetworkAdapters[$NICIndex] | Set-VMNetworkAdapter -StaticMacAddress $MACAddress
 
         # Can not move a off VM to paused, but only to running state
-        if($originalState -eq "Running")
+        if ($originalState -eq "Running")
         {
             Set-VMState -Name $Name -State Running -WaitForIP $WaitForIP
         }
 
         # Cannot make a paused VM to go back to Paused state after turning Off
-        if($originalState -eq "Paused")
+        if ($originalState -eq "Paused")
         {
             Write-Warning -Message ($localizedData.VMStateWillBeOffWarning -f $Name)
         }
     }
-    elseif($originalState -eq "Off")
+    elseif ($originalState -eq "Off")
     {
         $vmObj.NetworkAdapters[$NICIndex] | Set-VMNetworkAdapter -StaticMacAddress $MACAddress
         Write-Verbose -Message ($localizedData.VMPropertySet -f 'MACAddress', $MACAddress)

--- a/README.md
+++ b/README.md
@@ -267,10 +267,13 @@ The following properties **cannot** be changed after VM creation:
  __only on generation 2 virtual machines__.
  The default value is $true.
 * **`[Uint64]` StartupMemory** _(Write)_: Startup RAM for the VM.
+  If neither MinimumMemory nor MaximumMemory is specified, dynamic memory will be disabled.
 * **`[Uint64]` MinimumMemory** _(Write)_: Minimum RAM for the VM.
-  Setting this property enables dynamic memory.
+  Setting this property enables dynamic memory. Exception:
+  If MinimumMemory, MaximumMemory and StartupMemory is equal, dynamic memory will be disabled.
 * **`[Uint64]` MaximumMemory** _(Write)_: Maximum RAM for the VM.
-  Setting this property enables dynamic memory.
+  Setting this property enables dynamic memory. Exception:
+  If MinimumMemory, MaximumMemory and StartupMemory is equal, dynamic memory will be disabled.
 * **`[String[]]` MACAddress** _(Write)_: MAC address(es) of the VM.
   Multiple MAC addresses can now be assigned.
 * **`[Uint32]` ProcessorCount** _(Write)_: Processor count for the VM.

--- a/Tests/Unit/MSFT_xVMHyperV.Tests.ps1
+++ b/Tests/Unit/MSFT_xVMHyperV.Tests.ps1
@@ -35,6 +35,7 @@ Describe 'xVMHyper-V' {
         function Enable-VMIntegrationService { param ([Parameter(ValueFromPipeline)] $VM, $Name)}
         function Disable-VMIntegrationService { param ([Parameter(ValueFromPipeline)] $VM, $name)}
         function Get-VHD { param ( $Path ) }
+        function Set-VMMemory { }
 
         $stubVhdxDisk = New-Item -Path 'TestDrive:\TestVM.vhdx' -ItemType File;
         $studVhdxDiskSnapshot = New-Item -Path "TestDrive:\TestVM_D0145678-1576-4435-AB18-9F000C1C17D0.avhdx"  -ItemType File;
@@ -247,7 +248,6 @@ Describe 'xVMHyper-V' {
 
             It 'Returns $true when VM has snapshot chain' {
                 Mock -CommandName Get-VhdHierarchy -MockWith { Write-Host $VhdPath; return @($studVhdxDiskSnapshot, $stubVhdxDisk); }
-
                 Test-TargetResource -Name 'Generation2VM' -VhdPath $stubVhdxDisk -Verbose | Should Be $true;
             }
 


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please prefix the PR title with the resource name, i.e. 'xVMSwitch - My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xVMSwitch - My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
xHyper-V - Enable / disable dynamic memory for client and server SKUs in identical way.

**This Pull Request (PR) fixes the following issues:**
Fixes #89 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated / added?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xhyper-v/120)
<!-- Reviewable:end -->
