### PR TITLE
xVMHyperV - AutomaticCheckpointsUnsupported var name incorrect

### DIFF
--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -737,7 +737,7 @@ function Test-TargetResource
         # If AutomaticCheckpoints are supported, parameter exists on Set-VM
         if (-Not (Get-Command -Name Set-VM -Module Hyper-V).Parameters.ContainsKey('AutomaticCheckpointsEnabled'))
         {
-            Throw ($localizedData.AutomaticCheckpointsUnsupportedError)
+            Throw ($localizedData.AutomaticCheckpointsUnsupported)
         }
     }
 


### PR DESCRIPTION
**Pull Request (PR) description**

`AutomaticCheckpointsUnsupportedError` on line 740  does not resolve to a defined localized data variable and it looks like it should be `AutomaticCheckpointsUnsupported` instead. Without this change a meaningless error message is produced: `ScriptHalted` instead of  what is should be: `AutomaticCheckpoints are not supported on this host`. 

**Task list:**
- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated / added?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xhyper-v/148)
<!-- Reviewable:end -->
