### PR TITLE
xVMHyperV: Redoing abondoned PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* MSFT_xVMHyperV:
+  * Moved localization string data to own file
+  * Fixed code styling issues
+  * Fixed bug where StartupMemory was not evaluated in Test-TargetResource
+  * Redo of abandoned PRs
+    * [PR #148](https://github.com/PowerShell/xHyper-V/pull/148), Fixes [Issue #149](https://github.com/PowerShell/xHyper-V/issues/149)
+    * [PR #67](https://github.com/PowerShell/xHyper-V/pull/67), Fixes [Issue #145](https://github.com/PowerShell/xHyper-V/issues/145)
+
 ## 3.14.0.0
 
 * MSFT_xVMHost:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,17 @@
 ## Unreleased
 
 * MSFT_xVMHyperV:
-  * Moved localization string data to own file
-  * Fixed code styling issues
-  * Fixed bug where StartupMemory was not evaluated in Test-TargetResource
-  * Redo of abandoned PRs
-    * [PR #148](https://github.com/PowerShell/xHyper-V/pull/148), Fixes [Issue #149](https://github.com/PowerShell/xHyper-V/issues/149)
-    * [PR #67](https://github.com/PowerShell/xHyper-V/pull/67), Fixes [Issue #145](https://github.com/PowerShell/xHyper-V/issues/145)
-  * Fixed Get throws error when NetworkAdapters are not attached or missing properties
+  * Moved localization string data to own file.
+  * Fixed code styling issues.
+  * Fixed bug where StartupMemory was not evaluated in Test-TargetResource.
+  * Redo of abandoned PRs:
+    * [PR #148](https://github.com/PowerShell/xHyper-V/pull/148), Fixes [Issue #149](https://github.com/PowerShell/xHyper-V/issues/149).
+    * [PR #67](https://github.com/PowerShell/xHyper-V/pull/67), Fixes [Issue #145](https://github.com/PowerShell/xHyper-V/issues/145).
+  * Fixed Get throws error when NetworkAdapters are not attached or missing properties.
 
 ## 3.15.0.0
 
-* Explicitly removed extra hidden files from release package
+* Explicitly removed extra hidden files from release package.
 
 ## 3.14.0.0
 
@@ -40,12 +40,12 @@
   * MSFT_xVMHardDiskDrive to manage additional attached VHD/Xs.
   * MSFT_xVMScsiController to manage virtual machine SCSI controllers.
 * MSFT_xVMSwitch:
-  * Added parameter to specify the Load Balancing Algorithm of a vSwitch with Switch Embedded Teaming (SET)
+  * Added parameter to specify the Load Balancing Algorithm of a vSwitch with Switch Embedded Teaming (SET).
 
 ## 3.10.0.0
 
 * MSFT_xVMHyperV:
-  * Added support for configuring automatic snapshots
+  * Added support for configuring automatic snapshots.
 
 ## 3.9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Redo of abandoned PRs
     * [PR #148](https://github.com/PowerShell/xHyper-V/pull/148), Fixes [Issue #149](https://github.com/PowerShell/xHyper-V/issues/149)
     * [PR #67](https://github.com/PowerShell/xHyper-V/pull/67), Fixes [Issue #145](https://github.com/PowerShell/xHyper-V/issues/145)
+  * Fixed Get throws error when NetworkAdapters are not attached or missing properties
 
 ## 3.14.0.0
 

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -70,16 +70,18 @@ function Get-TargetResource
     $switchName = @()
     $ipAddress = @()
 
-    foreach ($n in $vmobj.NetworkAdapters)
+    foreach ($networkAdapter in $vmobj.NetworkAdapters)
     {
-        $macAddress += $n.MacAddress
-        if (-Not ([string]::IsNullOrEmpty($n.SwitchName)))
+        $macAddress += $networkAdapter.MacAddress
+
+        if (-Not ([string]::IsNullOrEmpty($networkAdapter.SwitchName)))
         {
-            $switchName += $n.SwitchName
+            $switchName += $networkAdapter.SwitchName
         }
-        if ($n.IPAddresses.Count -ge 1)
+
+        if ($networkAdapter.IPAddresses.Count -ge 1)
         {
-            $ipAddress += $n.IPAddresses
+            $ipAddress += $networkAdapter.IPAddresses
         }
     }
 

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -201,7 +201,7 @@ function Set-TargetResource
         # If AutomaticCheckpoints are supported, parameter exists on Set-VM
         if (-Not (Get-Command -Name Set-VM -Module Hyper-V).Parameters.ContainsKey('AutomaticCheckpointsEnabled'))
         {
-            Throw ($localizedData.AutomaticCheckpointsUnsupportedError)
+            Throw ($localizedData.AutomaticCheckpointsUnsupported)
         }
     }
 
@@ -679,7 +679,7 @@ function Test-TargetResource
         # If AutomaticCheckpoints are supported, parameter exists on Set-VM
         if (-Not (Get-Command -Name Set-VM -Module Hyper-V).Parameters.ContainsKey('AutomaticCheckpointsEnabled'))
         {
-            Throw ($localizedData.AutomaticCheckpointsUnsupportedError)
+            Throw ($localizedData.AutomaticCheckpointsUnsupported)
         }
     }
 

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
     # Check if 1 or 0 VM with name = $name exist
     if ($vmobj.count -gt 1)
     {
-       Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
+        Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
     }
 
     # Retrieve the Vhd hierarchy to ensure we enumerate snapshots/differencing disks
@@ -53,8 +53,8 @@ function Get-TargetResource
     $vmSecureBootState = $false
     if ($vmobj.Generation -eq 2)
     {
-       # Retrieve secure boot status (can only be enabled on Generation 2 VMs) and convert to a boolean.
-       $vmSecureBootState = ($vmobj | Get-VMFirmware).SecureBoot -eq 'On'
+        # Retrieve secure boot status (can only be enabled on Generation 2 VMs) and convert to a boolean.
+        $vmSecureBootState = ($vmobj | Get-VMFirmware).SecureBoot -eq 'On'
     }
 
     $guestServiceId = 'Microsoft:{0}\6C09BB55-D683-4DA0-8931-C9BF705F6480' -f $vmObj.Id
@@ -62,7 +62,7 @@ function Get-TargetResource
     @{
         Name               = $Name
         # Return the Vhd specified if it exists in the Vhd chain
-        VhdPath            = if ($vhdChain -contains $VhdPath) { $VhdPath };
+        VhdPath            = if ($vhdChain -contains $VhdPath) { $VhdPath }
         SwitchName         = $vmObj.NetworkAdapters.SwitchName
         State              = $vmobj.State
         Path               = $vmobj.Path
@@ -73,7 +73,7 @@ function Get-TargetResource
         MaximumMemory      = $vmobj.MemoryMaximum
         MACAddress         = $vmObj.NetWorkAdapters.MacAddress
         ProcessorCount     = $vmobj.ProcessorCount
-        Ensure             = if ($vmobj){"Present"} else {"Absent"}
+        Ensure             = if ($vmobj) { 'Present'} else { 'Absent' }
         ID                 = $vmobj.Id
         Status             = $vmobj.Status
         CPUUsage           = $vmobj.CPUUsage
@@ -109,7 +109,7 @@ function Set-TargetResource
 
         # State of the VM
         [Parameter()]
-        [ValidateSet('Running','Paused','Off')]
+        [ValidateSet('Running', 'Paused', 'Off')]
         [String]
         $State,
 
@@ -120,25 +120,25 @@ function Set-TargetResource
 
         # Virtual machine generation
         [Parameter()]
-        [ValidateRange(1,2)]
+        [ValidateRange(1, 2)]
         [UInt32]
         $Generation = 1,
 
         # Startup RAM for the VM
         [Parameter()]
-        [ValidateRange(32MB,65536MB)]
+        [ValidateRange(32MB, 65536MB)]
         [UInt64]
         $StartupMemory,
 
         # Minimum RAM for the VM. This enables dynamic memory
         [Parameter()]
-        [ValidateRange(32MB,65536MB)]
+        [ValidateRange(32MB, 65536MB)]
         [UInt64]
         $MinimumMemory,
 
         # Maximum RAM for the VM. This enables dynamic memory
         [Parameter()]
-        [ValidateRange(32MB,1048576MB)]
+        [ValidateRange(32MB, 1048576MB)]
         [UInt64]
         $MaximumMemory,
 
@@ -164,7 +164,7 @@ function Set-TargetResource
 
         # Should the VM be created or deleted
         [Parameter()]
-        [ValidateSet('Present','Absent')]
+        [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
@@ -195,7 +195,7 @@ function Set-TargetResource
     }
 
     # Check if AutomaticCheckpointsEnabled is set in configuration
-    if($PSBoundParameters.ContainsKey("AutomaticCheckpointsEnabled"))
+    if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
     {
         # Check if AutomaticCheckpoints are supported
         # If AutomaticCheckpoints are supported, parameter exists on Set-VM
@@ -214,7 +214,7 @@ function Set-TargetResource
         Write-Verbose -Message ($localizedData.VMExists -f $Name)
 
         # If VM shouldn't be there, stop it and remove it
-        if ($Ensure -eq "Absent")
+        if ($Ensure -eq 'Absent')
         {
             Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'Ensure', $Ensure, 'Present')
             Get-VM $Name | Stop-VM -Force -Passthru -WarningAction SilentlyContinue | Remove-VM -Force
@@ -238,34 +238,34 @@ function Set-TargetResource
             if ($PSBoundParameters.ContainsKey('StartupMemory') -and ($vmObj.MemoryStartup -ne $StartupMemory))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MemoryStartup', $StartupMemory, $vmObj.MemoryStartup)
-                $changeProperty["MemoryStartup"] = $StartupMemory
+                $changeProperty['MemoryStartup'] = $StartupMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($vmObj.MemoryStartup -lt $MinimumMemory))
             {
                 Write-Verbose -Message ($localizedData.AdjustingLessThanMemoryWarning -f 'StartupMemory', $vmObj.MemoryStartup, 'MinimumMemory', $MinimumMemory)
-                $changeProperty["MemoryStartup"] = $MinimumMemory
+                $changeProperty['MemoryStartup'] = $MinimumMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($vmObj.MemoryStartup -gt $MaximumMemory))
             {
                 Write-Verbose -Message ($localizedData.AdjustingGreaterThanMemoryWarning -f 'StartupMemory', $vmObj.MemoryStartup, 'MaximumMemory', $MaximumMemory)
-                $changeProperty["MemoryStartup"] = $MaximumMemory
+                $changeProperty['MemoryStartup'] = $MaximumMemory
             }
 
             # If the VM does not have the right minimum or maximum memory, stop the VM, set the right memory, start the VM
             if ($PSBoundParameters.ContainsKey('MinimumMemory') -or $PSBoundParameters.ContainsKey('MaximumMemory'))
             {
-                $changeProperty["DynamicMemory"] = $true
-                $changeProperty["StaticMemory"] = $false
+                $changeProperty['DynamicMemory'] = $true
+                $changeProperty['StaticMemory'] = $false
 
                 if ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($vmObj.Memoryminimum -ne $MinimumMemory))
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MinimumMemory', $MinimumMemory, $vmObj.MemoryMinimum)
-                    $changeProperty["MemoryMinimum"] = $MinimumMemory
+                    $changeProperty['MemoryMinimum'] = $MinimumMemory
                 }
                 if ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($vmObj.Memorymaximum -ne $MaximumMemory))
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'MaximumMemory', $MaximumMemory, $vmObj.MemoryMaximum)
-                    $changeProperty["MemoryMaximum"] = $MaximumMemory
+                    $changeProperty['MemoryMaximum'] = $MaximumMemory
                 }
             }
 
@@ -273,13 +273,13 @@ function Set-TargetResource
             if ($PSBoundParameters.ContainsKey('ProcessorCount') -and ($vmObj.ProcessorCount -ne $ProcessorCount))
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'ProcessorCount', $ProcessorCount, $vmObj.ProcessorCount)
-                $changeProperty["ProcessorCount"] = $ProcessorCount
+                $changeProperty['ProcessorCount'] = $ProcessorCount
             }
 
             # Stop the VM, set the right properties, start the VM only if there are properties to change
             if ($changeProperty.Count -gt 0)
             {
-                Set-VMProperty -Name $Name -VMCommand "Set-VM" -ChangeProperty $changeProperty -WaitForIP $WaitForIP -RestartIfNeeded $RestartIfNeeded
+                Set-VMProperty -Name $Name -VMCommand 'Set-VM' -ChangeProperty $changeProperty -WaitForIP $WaitForIP -RestartIfNeeded $RestartIfNeeded
                 Write-Verbose -Message ($localizedData.VMPropertiesUpdated -f $Name)
             }
 
@@ -289,14 +289,14 @@ function Set-TargetResource
                 - If only startup memory is specified, but neither minimum nor maximum
             #>
             if ( ($PSBoundParameters.ContainsKey('StartupMemory') -and
-                   ($StartupMemory -eq $MinimumMemory) -and
-                   ($StartupMemory -eq $MaximumMemory)
-                 ) -or
-                 ( $PSBoundParameters.ContainsKey('StartupMemory') -and
-                   (-not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
-                   (-not $PSBoundParameters.ContainsKey('MaximumMemory'))
-                 )
-               )
+                    ($StartupMemory -eq $MinimumMemory) -and
+                    ($StartupMemory -eq $MaximumMemory)
+                ) -or
+                ( $PSBoundParameters.ContainsKey('StartupMemory') -and
+                    (-not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
+                    (-not $PSBoundParameters.ContainsKey('MaximumMemory'))
+                )
+            )
             {
                 # Refresh VM properties
                 $vmObj = Get-VM -Name $Name -ErrorAction SilentlyContinue
@@ -323,15 +323,18 @@ function Set-TargetResource
             {
                 $switch = $SwitchName[$i]
                 $nic = $vmObj.NetworkAdapters[$i]
-                if ($nic) {
+                if ($nic)
+                {
                     # We cannot change the MAC address whilst the VM is running.. This is changed later
-                    if ($nic.SwitchName -ne $switch) {
+                    if ($nic.SwitchName -ne $switch)
+                    {
                         Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'NIC', $switch, $nic.SwitchName)
                         $nic | Connect-VMNetworkAdapter -SwitchName $switch
                         Write-Verbose -Message ($localizedData.VMPropertySet -f 'NIC', $switch)
                     }
                 }
-                else {
+                else
+                {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'NIC', $switch, '<missing>')
                     if ($MACAddress -and (-not [System.String]::IsNullOrEmpty($MACAddress[$i])))
                     {
@@ -376,6 +379,7 @@ function Set-TargetResource
                     {
                         $enableSecureBoot = 'Off'
                     }
+
                     # Cannot change the secure boot state whilst the VM is powered on.
                     $setVMPropertyParams = @{
                         VMName = $Name
@@ -417,7 +421,7 @@ function Set-TargetResource
             # If AutomaticCheckpointsEnabled is set in configuration
             if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
             {
-                if($vmObj.AutomaticCheckpointsEnabled -ne $AutomaticCheckpointsEnabled)
+                if ($vmObj.AutomaticCheckpointsEnabled -ne $AutomaticCheckpointsEnabled)
                 {
                     Set-VM -Name $Name -AutomaticCheckpointsEnabled $AutomaticCheckpointsEnabled
                 }
@@ -429,71 +433,71 @@ function Set-TargetResource
     else
     {
         Write-Verbose -Message ($localizedData.VMDoesNotExist -f $Name)
-        if ($Ensure -eq "Present")
+        if ($Ensure -eq 'Present')
         {
             Write-Verbose -Message ($localizedData.CreatingVM -f $Name)
 
             $parameters = @{}
-            $parameters["Name"] = $Name
-            $parameters["VHDPath"] = $VhdPath
-            $parameters["Generation"] = $Generation
+            $parameters['Name'] = $Name
+            $parameters['VHDPath'] = $VhdPath
+            $parameters['Generation'] = $Generation
 
             # Optional parameters
             if ($SwitchName)
             {
-                $parameters["SwitchName"] = $SwitchName[0]
+                $parameters['SwitchName'] = $SwitchName[0]
             }
             if ($Path)
             {
-                $parameters["Path"] = $Path
+                $parameters['Path'] = $Path
             }
             $defaultStartupMemory = 512MB
             if ($PSBoundParameters.ContainsKey('StartupMemory'))
             {
-                $parameters["MemoryStartupBytes"] = $StartupMemory
+                $parameters['MemoryStartupBytes'] = $StartupMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MinimumMemory') -and ($defaultStartupMemory -lt $MinimumMemory))
             {
-                $parameters["MemoryStartupBytes"] = $MinimumMemory
+                $parameters['MemoryStartupBytes'] = $MinimumMemory
             }
             elseif ($PSBoundParameters.ContainsKey('MaximumMemory') -and ($defaultStartupMemory -gt $MaximumMemory))
             {
-                $parameters["MemoryStartupBytes"] = $MaximumMemory
+                $parameters['MemoryStartupBytes'] = $MaximumMemory
             }
             $null = New-VM @parameters
 
             $parameters = @{}
-            $parameters["Name"] = $Name
-            $parameters["StaticMemory"] = $true
-            $parameters["DynamicMemory"] = $false
+            $parameters['Name'] = $Name
+            $parameters['StaticMemory'] = $true
+            $parameters['DynamicMemory'] = $false
             if ($PSBoundParameters.ContainsKey('MinimumMemory') -or $PSBoundParameters.ContainsKey('MaximumMemory'))
             {
-                $parameters["DynamicMemory"] = $true
-                $parameters["StaticMemory"] = $false
+                $parameters['DynamicMemory'] = $true
+                $parameters['StaticMemory'] = $false
                 if ($PSBoundParameters.ContainsKey('MinimumMemory'))
                 {
-                    $parameters["MemoryMinimumBytes"] = $MinimumMemory
+                    $parameters['MemoryMinimumBytes'] = $MinimumMemory
                 }
                 if ($PSBoundParameters.ContainsKey('MaximumMemory'))
                 {
-                    $parameters["MemoryMaximumBytes"] = $MaximumMemory
+                    $parameters['MemoryMaximumBytes'] = $MaximumMemory
                 }
             }
 
             if ($Notes)
             {
-                $parameters["Notes"] = $Notes
+                $parameters['Notes'] = $Notes
             }
 
             if ($PSBoundParameters.ContainsKey('ProcessorCount'))
             {
-                $parameters["ProcessorCount"] = $ProcessorCount
+                $parameters['ProcessorCount'] = $ProcessorCount
             }
 
             # If AutomaticCheckpointsEnabled is set in configuration
             if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
             {
-                $parameters["AutomaticCheckpointsEnabled"]=$AutomaticCheckpointsEnabled
+                $parameters['AutomaticCheckpointsEnabled'] = $AutomaticCheckpointsEnabled
             }
 
             $null = Set-VM @parameters
@@ -516,7 +520,7 @@ function Set-TargetResource
             for ($i = 1; $i -lt $SwitchName.Count; $i++)
             {
                 $addVMNetworkAdapterParams = @{
-                    VMName = $Name;
+                    VMName = $Name
                     SwitchName = $SwitchName[$i]
                 }
                 if ($MACAddress -and (-not [System.String]::IsNullOrEmpty($MACAddress[$i])))
@@ -527,7 +531,8 @@ function Set-TargetResource
                 Write-Verbose -Message ($localizedData.VMPropertySet -f 'NIC', $SwitchName[$i])
             }
 
-            if ($Generation -eq 2) {
+            if ($Generation -eq 2)
+            {
                 # Secure boot is only applicable to Generation 2 VMs and it defaults to on.
                 # Therefore, we only need to explicitly set it to off if specified.
                 if ($SecureBoot -eq $false)
@@ -577,7 +582,7 @@ function Test-TargetResource
 
         # State of the VM
         [Parameter()]
-        [ValidateSet('Running','Paused','Off')]
+        [ValidateSet('Running', 'Paused', 'Off')]
         [String]
         $State,
 
@@ -588,25 +593,25 @@ function Test-TargetResource
 
         # Virtual machine generation
         [Parameter()]
-        [ValidateRange(1,2)]
+        [ValidateRange(1, 2)]
         [UInt32]
         $Generation = 1,
 
         # Startup RAM for the VM
         [Parameter()]
-        [ValidateRange(32MB,65536MB)]
+        [ValidateRange(32MB, 65536MB)]
         [UInt64]
         $StartupMemory,
 
         # Minimum RAM for the VM. This enables dynamic memory
         [Parameter()]
-        [ValidateRange(32MB,65536MB)]
+        [ValidateRange(32MB, 65536MB)]
         [UInt64]
         $MinimumMemory,
 
         # Maximum RAM for the VM. This enables dynamic memory
         [Parameter()]
-        [ValidateRange(32MB,1048576MB)]
+        [ValidateRange(32MB, 1048576MB)]
         [UInt64]
         $MaximumMemory,
 
@@ -632,7 +637,7 @@ function Test-TargetResource
 
         # Should the VM be created or deleted
         [Parameter()]
-        [ValidateSet('Present','Absent')]
+        [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
@@ -664,11 +669,11 @@ function Test-TargetResource
     # Check if 1 or 0 VM with name = $name exist
     if ((Get-VM -Name $Name -ErrorAction SilentlyContinue).count -gt 1)
     {
-       Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
+        Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
     }
 
     # Check if AutomaticCheckpointsEnabled is set in configuration
-    if($PSBoundParameters.ContainsKey("AutomaticCheckpointsEnabled"))
+    if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
     {
         # Check if AutomaticCheckpoints are supported
         # If AutomaticCheckpoints are supported, parameter exists on Set-VM
@@ -758,9 +763,9 @@ function Test-TargetResource
 
             # If startup memory but neither minimum nor maximum memory specified, dynamic memory should be disabled
             if ($PSBoundParameters.ContainsKey('$StartupMemory') -and
-               ( -not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
-               ( -not $PSBoundParameters.ContainsKey('MaximumMemory')) -and
-               $vmobj.DynamicMemoryEnabled)
+                ( -not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
+                ( -not $PSBoundParameters.ContainsKey('MaximumMemory')) -and
+                $vmobj.DynamicMemoryEnabled)
             {
                 return $false
             }
@@ -810,7 +815,8 @@ function Test-TargetResource
                 return $false
             }
 
-            if ($vmObj.Generation -eq 2) {
+            if ($vmObj.Generation -eq 2)
+            {
                 $vmSecureBoot = Test-VMSecureBoot -Name $Name
                 if ($SecureBoot -ne $vmSecureBoot)
                 {
@@ -821,7 +827,7 @@ function Test-TargetResource
 
             $guestServiceId = 'Microsoft:{0}\6C09BB55-D683-4DA0-8931-C9BF705F6480' -f $vmObj.Id
             $guestService = $vmObj | Get-VMIntegrationService | Where-Object -FilterScript {$_.Id -eq $guestServiceId}
-            if ($guestService.Enabled  -ne $EnableGuestService)
+            if ($guestService.Enabled -ne $EnableGuestService)
             {
                 Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'EnableGuestService', $EnableGuestService, $guestService.Enabled)
                 return $false
@@ -830,7 +836,7 @@ function Test-TargetResource
             # If AutomaticCheckpointsEnabled is set in configuration
             if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
             {
-                if($vmObj.AutomaticCheckpointsEnabled -ne $AutomaticCheckpointsEnabled)
+                if ($vmObj.AutomaticCheckpointsEnabled -ne $AutomaticCheckpointsEnabled)
                 {
                     Write-Verbose -Message ($localizedData.VMPropertyShouldBe -f 'AutomaticCheckpointsEnabled', $AutomaticCheckpointsEnabled, $vmObj.AutomaticCheckpointsEnabled)
                     return $false
@@ -864,7 +870,7 @@ function Get-VhdHierarchy
 
     $vmVhdPath = Get-VHD -Path $VhdPath
     Write-Output -InputObject $vmVhdPath.Path
-    while(-not [System.String]::IsNullOrEmpty($vmVhdPath.ParentPath))
+    while (-not [System.String]::IsNullOrEmpty($vmVhdPath.ParentPath))
     {
         $vmVhdPath.ParentPath
         $vmVhdPath = (Get-VHD -Path $vmVhdPath.ParentPath)
@@ -899,24 +905,24 @@ function Set-VMMACAddress
     )
     $vmObj = Get-VM -Name $Name
     $originalState = $vmObj.state
-    if ($originalState -ne "Off" -and $RestartIfNeeded)
+    if ($originalState -ne 'Off' -and $RestartIfNeeded)
     {
         Set-VMState -Name $Name -State Off
         $vmObj.NetworkAdapters[$NICIndex] | Set-VMNetworkAdapter -StaticMacAddress $MACAddress
 
         # Can not move a off VM to paused, but only to running state
-        if ($originalState -eq "Running")
+        if ($originalState -eq 'Running')
         {
             Set-VMState -Name $Name -State Running -WaitForIP $WaitForIP
         }
 
         # Cannot make a paused VM to go back to Paused state after turning Off
-        if ($originalState -eq "Paused")
+        if ($originalState -eq 'Paused')
         {
             Write-Warning -Message ($localizedData.VMStateWillBeOffWarning -f $Name)
         }
     }
-    elseif ($originalState -eq "Off")
+    elseif ($originalState -eq 'Off')
     {
         $vmObj.NetworkAdapters[$NICIndex] | Set-VMNetworkAdapter -StaticMacAddress $MACAddress
         Write-Verbose -Message ($localizedData.VMPropertySet -f 'MACAddress', $MACAddress)

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -32,6 +32,8 @@ function Get-TargetResource
         $VhdPath
     )
 
+    Write-Verbose -Message ($localizedData.QueryingVM -f $Name)
+
     # Check if Hyper-V module is present for Hyper-V cmdlets
     if (!(Get-Module -ListAvailable -Name Hyper-V))
     {
@@ -62,7 +64,7 @@ function Get-TargetResource
     @{
         Name               = $Name
         # Return the Vhd specified if it exists in the Vhd chain
-        VhdPath            = if ($vhdChain -contains $VhdPath) { $VhdPath }
+        VhdPath            = if ($vhdChain -contains $VhdPath) { $VhdPath } else { $null }
         SwitchName         = $vmObj.NetworkAdapters.SwitchName
         State              = $vmobj.State
         Path               = $vmobj.Path

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -1,34 +1,16 @@
-# Fallback message strings in en-US
-DATA localizedData
+#region localizeddata
+if (Test-Path "${PSScriptRoot}\${PSUICulture}")
 {
-    # culture = "en-US"
-    ConvertFrom-StringData @'
-        RoleMissingError = Please ensure that '{0}' role is installed with its PowerShell module.
-        MoreThanOneVMExistsError = More than one VM with the name '{0}' exists.
-        PathDoesNotExistError = Path '{0}' does not exist.
-        VhdPathDoesNotExistError = Vhd '{0}' does not exist.
-        MinMemGreaterThanStartupMemError = MinimumMemory '{0}' should not be greater than StartupMemory '{1}'
-        MinMemGreaterThanMaxMemError = MinimumMemory '{0}' should not be greater than MaximumMemory '{1}'
-        StartUpMemGreaterThanMaxMemError = StartupMemory '{0}' should not be greater than MaximumMemory '{1}'.
-        VhdUnsupportedOnGen2VMError = Generation 2 virtual machines do not support the .VHD virtual disk extension.
-        CannotUpdatePropertiesOnlineError = Can not change properties for VM '{0}' in '{1}' state unless 'RestartIfNeeded' is set to true.
-        AutomaticCheckpointsUnsupported = AutomaticCheckpoints are not supported on this host.
-
-        AdjustingGreaterThanMemoryWarning = VM {0} '{1}' is greater than {2} '{3}'. Adjusting {0} to be '{3}'.
-        AdjustingLessThanMemoryWarning = VM {0} '{1}' is less than {2} '{3}'. Adjusting {0} to be '{3}'.
-        VMStateWillBeOffWarning = VM '{0}' state will be 'OFF' and not 'Paused'.
-
-        CheckingVMExists = Checking if VM '{0}' exists ...
-        VMExists = VM '{0}' exists.
-        VMDoesNotExist = VM '{0}' does not exist.
-        CreatingVM = Creating VM '{0}' ...
-        VMCreated = VM '{0}' created.
-        VMPropertyShouldBe = VM property '{0}' should be '{1}', actual '{2}'.
-        VMPropertySet = VM property '{0}' is '{1}'.
-        VMPropertiesUpdated = VM '{0}' properties have been updated.
-        WaitingForVMIPAddress = Waiting for IP Address for VM '{0}' ...
-'@
+    Import-LocalizedData -BindingVariable localizedData -Filename MSFT_xVMHyperV.psd1 `
+        -BaseDirectory "${PSScriptRoot}\${PSUICulture}"
 }
+else
+{
+    # fallback to en-US
+    Import-LocalizedData -BindingVariable localizedData -Filename MSFT_xVMHyperV.psd1 `
+        -BaseDirectory "${PSScriptRoot}\en-US"
+}
+#endregion
 
 # Import the common HyperV functions
 Import-Module -Name ( Join-Path `

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -48,8 +48,10 @@ function Get-TargetResource
         Throw ($localizedData.MoreThanOneVMExistsError -f $Name)
     }
 
-    # Retrieve the Vhd hierarchy to ensure we enumerate snapshots/differencing disks
-    # Fixes #28
+    <#
+        Retrieve the Vhd hierarchy to ensure we enumerate snapshots/differencing disks
+        Fixes #28
+    #>
     if ($null -ne $vmobj)
     {
         $vhdChain = @(Get-VhdHierarchy -VhdPath ($vmObj.HardDrives[0].Path))
@@ -219,8 +221,10 @@ function Set-TargetResource
     # Check if AutomaticCheckpointsEnabled is set in configuration
     if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
     {
-        # Check if AutomaticCheckpoints are supported
-        # If AutomaticCheckpoints are supported, parameter exists on Set-VM
+        <#
+            Check if AutomaticCheckpoints are supported
+            If AutomaticCheckpoints are supported, parameter exists on Set-VM
+        #>
         if (-Not (Get-Command -Name Set-VM -Module Hyper-V).Parameters.ContainsKey('AutomaticCheckpointsEnabled'))
         {
             Throw ($localizedData.AutomaticCheckpointsUnsupported)
@@ -243,8 +247,10 @@ function Set-TargetResource
             Write-Verbose -Message ($localizedData.VMPropertySet -f 'Ensure', $Ensure)
         }
 
-        # If VM is present, check its state, startup memory, minimum memory, maximum memory,processor count, automatic checkpoint and mac address
-        # One cannot set the VM's vhdpath, path, generation and switchName after creation
+        <#
+            If VM is present, check its state, startup memory, minimum memory, maximum memory,processor count, automatic checkpoint and mac address
+            One cannot set the VM's vhdpath, path, generation and switchName after creation
+        #>
         else
         {
             # If state has been specified and the VM is not in right state, set it to right state
@@ -555,8 +561,10 @@ function Set-TargetResource
 
             if ($Generation -eq 2)
             {
-                # Secure boot is only applicable to Generation 2 VMs and it defaults to on.
-                # Therefore, we only need to explicitly set it to off if specified.
+                <#
+                    Secure boot is only applicable to Generation 2 VMs and it defaults to on.
+                    Therefore, we only need to explicitly set it to off if specified.
+                #>
                 if ($SecureBoot -eq $false)
                 {
                     Set-VMFirmware -VMName $Name -EnableSecureBoot Off
@@ -697,8 +705,10 @@ function Test-TargetResource
     # Check if AutomaticCheckpointsEnabled is set in configuration
     if ($PSBoundParameters.ContainsKey('AutomaticCheckpointsEnabled'))
     {
-        # Check if AutomaticCheckpoints are supported
-        # If AutomaticCheckpoints are supported, parameter exists on Set-VM
+        <#
+            Check if AutomaticCheckpoints are supported
+            If AutomaticCheckpoints are supported, parameter exists on Set-VM
+        #>
         if (-Not (Get-Command -Name Set-VM -Module Hyper-V).Parameters.ContainsKey('AutomaticCheckpointsEnabled'))
         {
             Throw ($localizedData.AutomaticCheckpointsUnsupported)
@@ -740,8 +750,10 @@ function Test-TargetResource
                 Throw ($localizedData.StartUpMemGreaterThanMaxMemError -f $StartupMemory, $MaximumMemory)
             }
 
-            <#  VM Generation has no direct relation to the virtual hard disk format and cannot be changed
-                after the virtual machine has been created. Generation 2 VMs do not support .VHD files.  #>
+            <#
+                VM Generation has no direct relation to the virtual hard disk format and cannot be changed
+                after the virtual machine has been created. Generation 2 VMs do not support .VHD files.
+            #>
             if (($Generation -eq 2) -and ($VhdPath.Split('.')[-1] -eq 'vhd'))
             {
                 Throw ($localizedData.VhdUnsupportedOnGen2VMError)
@@ -880,7 +892,7 @@ function Test-TargetResource
 
 #region Helper function
 
-<# Returns VM VHDs, including snapshots and differencing disks #>
+# Returns VM VHDs, including snapshots and differencing disks
 function Get-VhdHierarchy
 {
     param
@@ -899,8 +911,10 @@ function Get-VhdHierarchy
     }
 }
 
-# The 'Set-VMProperty' method cannot be used as it cannot deal with piped
-# command in it's current implementation
+<#
+    The 'Set-VMProperty' method cannot be used as it cannot deal with piped
+    command in it's current implementation
+#>
 function Set-VMMACAddress
 {
     param

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -762,7 +762,7 @@ function Test-TargetResource
             }
 
             # If startup memory but neither minimum nor maximum memory specified, dynamic memory should be disabled
-            if ($PSBoundParameters.ContainsKey('$StartupMemory') -and
+            if ($PSBoundParameters.ContainsKey('StartupMemory') -and
                 ( -not $PSBoundParameters.ContainsKey('MinimumMemory')) -and
                 ( -not $PSBoundParameters.ContainsKey('MaximumMemory')) -and
                 $vmobj.DynamicMemoryEnabled)

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -50,7 +50,10 @@ function Get-TargetResource
 
     # Retrieve the Vhd hierarchy to ensure we enumerate snapshots/differencing disks
     # Fixes #28
-    $vhdChain = @(Get-VhdHierarchy -VhdPath ($vmObj.HardDrives[0].Path))
+    if ($null -ne $vmobj)
+    {
+        $vhdChain = @(Get-VhdHierarchy -VhdPath ($vmObj.HardDrives[0].Path))
+    }
 
     $vmSecureBootState = $false
     if ($vmobj.Generation -eq 2)

--- a/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
+++ b/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.psm1
@@ -61,11 +61,28 @@ function Get-TargetResource
 
     $guestServiceId = 'Microsoft:{0}\6C09BB55-D683-4DA0-8931-C9BF705F6480' -f $vmObj.Id
 
+    $macAddress = @()
+    $switchName = @()
+    $ipAddress = @()
+
+    foreach ($n in $vmobj.NetworkAdapters)
+    {
+        $macAddress += $n.MacAddress
+        if (-Not ([string]::IsNullOrEmpty($n.SwitchName)))
+        {
+            $switchName += $n.SwitchName
+        }
+        if ($n.IPAddresses.Count -ge 1)
+        {
+            $ipAddress += $n.IPAddresses
+        }
+    }
+
     @{
         Name               = $Name
         # Return the Vhd specified if it exists in the Vhd chain
         VhdPath            = if ($vhdChain -contains $VhdPath) { $VhdPath } else { $null }
-        SwitchName         = $vmObj.NetworkAdapters.SwitchName
+        SwitchName         = $switchName
         State              = $vmobj.State
         Path               = $vmobj.Path
         Generation         = $vmobj.Generation
@@ -73,7 +90,7 @@ function Get-TargetResource
         StartupMemory      = $vmobj.MemoryStartup
         MinimumMemory      = $vmobj.MemoryMinimum
         MaximumMemory      = $vmobj.MemoryMaximum
-        MACAddress         = $vmObj.NetWorkAdapters.MacAddress
+        MACAddress         = $macAddress
         ProcessorCount     = $vmobj.ProcessorCount
         Ensure             = if ($vmobj) { 'Present'} else { 'Absent' }
         ID                 = $vmobj.Id
@@ -83,7 +100,7 @@ function Get-TargetResource
         Uptime             = $vmobj.Uptime
         CreationTime       = $vmobj.CreationTime
         HasDynamicMemory   = $vmobj.DynamicMemoryEnabled
-        NetworkAdapters    = $vmobj.NetworkAdapters.IPAddresses
+        NetworkAdapters    = $ipAddress
         EnableGuestService = ($vmobj | Get-VMIntegrationService | Where-Object -FilterScript {$_.Id -eq $guestServiceId}).Enabled
         AutomaticCheckpointsEnabled = $vmobj.AutomaticCheckpointsEnabled
     }

--- a/DSCResources/MSFT_xVMHyperV/en-US/MSFT_xVMHyperV.psd1
+++ b/DSCResources/MSFT_xVMHyperV/en-US/MSFT_xVMHyperV.psd1
@@ -23,4 +23,6 @@ ConvertFrom-StringData @'
     VMPropertySet                     = VM property '{0}' is '{1}'.
     VMPropertiesUpdated               = VM '{0}' properties have been updated.
     WaitingForVMIPAddress             = Waiting for IP Address for VM '{0}' ...
+
+    QueryingVM                        = Querying VM '{0}'.
 '@

--- a/DSCResources/MSFT_xVMHyperV/en-US/MSFT_xVMHyperV.psd1
+++ b/DSCResources/MSFT_xVMHyperV/en-US/MSFT_xVMHyperV.psd1
@@ -1,0 +1,26 @@
+ConvertFrom-StringData @'
+    RoleMissingError                  = Please ensure that '{0}' role is installed with its PowerShell module.
+    MoreThanOneVMExistsError          = More than one VM with the name '{0}' exists.
+    PathDoesNotExistError             = Path '{0}' does not exist.
+    VhdPathDoesNotExistError          = Vhd '{0}' does not exist.
+    MinMemGreaterThanStartupMemError  = MinimumMemory '{0}' should not be greater than StartupMemory '{1}'
+    MinMemGreaterThanMaxMemError      = MinimumMemory '{0}' should not be greater than MaximumMemory '{1}'
+    StartUpMemGreaterThanMaxMemError  = StartupMemory '{0}' should not be greater than MaximumMemory '{1}'.
+    VhdUnsupportedOnGen2VMError       = Generation 2 virtual machines do not support the .VHD virtual disk extension.
+    CannotUpdatePropertiesOnlineError = Can not change properties for VM '{0}' in '{1}' state unless 'RestartIfNeeded' is set to true.
+    AutomaticCheckpointsUnsupported   = AutomaticCheckpoints are not supported on this host.
+
+    AdjustingGreaterThanMemoryWarning = VM {0} '{1}' is greater than {2} '{3}'. Adjusting {0} to be '{3}'.
+    AdjustingLessThanMemoryWarning    = VM {0} '{1}' is less than {2} '{3}'. Adjusting {0} to be '{3}'.
+    VMStateWillBeOffWarning           = VM '{0}' state will be 'OFF' and not 'Paused'.
+
+    CheckingVMExists                  = Checking if VM '{0}' exists ...
+    VMExists                          = VM '{0}' exists.
+    VMDoesNotExist                    = VM '{0}' does not exist.
+    CreatingVM                        = Creating VM '{0}' ...
+    VMCreated                         = VM '{0}' created.
+    VMPropertyShouldBe                = VM property '{0}' should be '{1}', actual '{2}'.
+    VMPropertySet                     = VM property '{0}' is '{1}'.
+    VMPropertiesUpdated               = VM '{0}' properties have been updated.
+    WaitingForVMIPAddress             = Waiting for IP Address for VM '{0}' ...
+'@


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
* MSFT_xVMHyperV:
  * Moved localization string data to own file
  * Fixed code styling issues
  * Fixed bug where StartupMemory was not evaluated in Test-TargetResource
  * Redo of abandoned PRs
    * #148 
    * #67 
  * Fixed Get throws error when NetworkAdapters are not attached or missing properties

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
- Fixes #149 
- Fixes #145 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xhyper-v/163)
<!-- Reviewable:end -->
